### PR TITLE
SimplyCosplay: add Related & fix DTO

### DIFF
--- a/src/all/simplycosplay/build.gradle
+++ b/src/all/simplycosplay/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    kmkVersionCode = 1
     extName = 'Simply Cosplay'
     extClass = '.SimplyCosplay'
     extVersionCode = 2

--- a/src/all/simplycosplay/src/eu/kanade/tachiyomi/extension/all/simplycosplay/SimplyCosplay.kt
+++ b/src/all/simplycosplay/src/eu/kanade/tachiyomi/extension/all/simplycosplay/SimplyCosplay.kt
@@ -323,7 +323,21 @@ class SimplyCosplay : HttpSource(), ConfigurableSource {
                 Page(index, "", image.urls.url)
             }
         }
-            ?: Page(1, "", result.data.preview.urls.url).let(::listOf)
+            ?: Page(1, "", result.data.preview?.urls?.url).let(::listOf)
+    }
+
+    override fun relatedMangaListRequest(manga: SManga): Request {
+        val url = mangaUrlBuilder(manga.url).apply {
+            addQueryParameter("related", "25")
+        }
+
+        return GET(url.build(), headers)
+    }
+
+    override fun relatedMangaListParse(response: Response): List<SManga> {
+        val result = response.parseAs<detailsResponse>()
+
+        return result.data.related?.map(BrowseItem::toSManga) ?: emptyList()
     }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {

--- a/src/all/simplycosplay/src/eu/kanade/tachiyomi/extension/all/simplycosplay/SimplyCosplay.kt
+++ b/src/all/simplycosplay/src/eu/kanade/tachiyomi/extension/all/simplycosplay/SimplyCosplay.kt
@@ -323,7 +323,7 @@ class SimplyCosplay : HttpSource(), ConfigurableSource {
                 Page(index, "", image.urls.url)
             }
         }
-            ?: Page(1, "", result.data.preview?.urls?.url).let(::listOf)
+            ?: Page(1, "", (result.data.preview?.urls?.url ?: THUMBNAIL_PLACEHOLDER_URL)).let(::listOf)
     }
 
     override fun relatedMangaListRequest(manga: SManga): Request {
@@ -376,12 +376,14 @@ class SimplyCosplay : HttpSource(), ConfigurableSource {
         private const val DEFAULT_TOKEN_PREF = "default_token_pref"
         private const val DEFAULT_FALLBACK_TOKEN = "01730876"
         private const val TOKEN_EXCEPTION = "Unable to fetch new Token"
-        private val TokenRegex = Regex("""token\s*:\s*"([^\"]+)""")
+        private val TokenRegex = Regex("""token\s*:\s*"([^"]+)""")
 
         private val dateFormat by lazy { SimpleDateFormat("yyy-MM-dd'T'HH:mm:ss.SSS", Locale.ENGLISH) }
 
         private const val BROWSE_TYPE_PREF_KEY = "default_browse_type_key"
         private const val BROWSE_TYPE_TITLE = "Default Browse List"
+
+        const val THUMBNAIL_PLACEHOLDER_URL = "https://www.simply-cosplay.com/android-icon-192x192.png"
     }
 
     override fun chapterListParse(response: Response) =

--- a/src/all/simplycosplay/src/eu/kanade/tachiyomi/extension/all/simplycosplay/SimplyCosplayDto.kt
+++ b/src/all/simplycosplay/src/eu/kanade/tachiyomi/extension/all/simplycosplay/SimplyCosplayDto.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.all.simplycosplay
 
+import eu.kanade.tachiyomi.extension.all.simplycosplay.SimplyCosplay.Companion.THUMBNAIL_PLACEHOLDER_URL
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import kotlinx.serialization.Serializable
@@ -24,7 +25,7 @@ data class BrowseItem(
     fun toSManga() = SManga.create().apply {
         title = this@BrowseItem.title ?: ""
         url = "/${type.lowercase().trim()}/new/$slug"
-        thumbnail_url = preview?.urls?.thumb?.url
+        thumbnail_url = preview?.urls?.thumb?.url ?: THUMBNAIL_PLACEHOLDER_URL
         description = preview?.publish_date?.let { "Date: $it" }
     }
 }
@@ -54,7 +55,7 @@ data class DetailsResponse(
     val title: String? = null,
     val slug: String,
     val type: String,
-    val preview: Images,
+    val preview: Images?,
     val tags: List<Tag>? = emptyList(),
     val image_count: Int? = null,
     val related: List<BrowseItem>?,
@@ -62,7 +63,7 @@ data class DetailsResponse(
     fun toSManga() = SManga.create().apply {
         title = this@DetailsResponse.title ?: ""
         url = "/${type.lowercase().trim()}/new/$slug"
-        thumbnail_url = preview.urls.thumb.url
+        thumbnail_url = preview?.urls?.thumb?.url ?: THUMBNAIL_PLACEHOLDER_URL
         genre = tags?.mapNotNull { it ->
             it.name?.trim()?.split(" ")?.let { genre ->
                 genre.map {
@@ -81,7 +82,7 @@ data class DetailsResponse(
         description = buildString {
             append("Type: $type\n")
             image_count?.let { append("Images: $it\n") }
-            preview.publish_date?.let { append("Date: $it\n") }
+            preview?.publish_date?.let { append("Date: $it\n") }
         }
         update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
         status = SManga.COMPLETED

--- a/src/all/simplycosplay/src/eu/kanade/tachiyomi/extension/all/simplycosplay/SimplyCosplayDto.kt
+++ b/src/all/simplycosplay/src/eu/kanade/tachiyomi/extension/all/simplycosplay/SimplyCosplayDto.kt
@@ -19,13 +19,13 @@ data class BrowseItem(
     val title: String? = null,
     val slug: String,
     val type: String,
-    val preview: Images,
+    val preview: Images?,
 ) {
     fun toSManga() = SManga.create().apply {
         title = this@BrowseItem.title ?: ""
         url = "/${type.lowercase().trim()}/new/$slug"
-        thumbnail_url = preview.urls.thumb.url
-        description = preview.publish_date?.let { "Date: $it" }
+        thumbnail_url = preview?.urls?.thumb?.url
+        description = preview?.publish_date?.let { "Date: $it" }
     }
 }
 
@@ -57,6 +57,7 @@ data class DetailsResponse(
     val preview: Images,
     val tags: List<Tag>? = emptyList(),
     val image_count: Int? = null,
+    val related: List<BrowseItem>?,
 ) {
     fun toSManga() = SManga.create().apply {
         title = this@DetailsResponse.title ?: ""
@@ -90,7 +91,7 @@ data class DetailsResponse(
 @Serializable
 data class PageResponse(
     val images: List<Images>? = null,
-    val preview: Images,
+    val preview: Images?,
 )
 
 @Serializable


### PR DESCRIPTION
## Summary by Sourcery

Add related manga fetching and improve handling of missing cover previews with a fallback thumbnail URL.

New Features:
- Introduce relatedMangaListRequest and relatedMangaListParse to retrieve related manga items

Bug Fixes:
- Prevent null pointer exceptions by making preview fields nullable and falling back to a placeholder thumbnail URL
- Correct the TokenRegex pattern to properly capture token values

Enhancements:
- Update BrowseItem, DetailsResponse, and PageResponse DTOs to support optional preview data and related items
- Define THUMBNAIL_PLACEHOLDER_URL constant in the companion object for use as a default thumbnail

Build:
- Add kmkVersionCode property to build.gradle