### PR TITLE
SpyFakku: Support Latest browsing & disable supportsRelatedMangas

### DIFF
--- a/src/en/spyfakku/build.gradle
+++ b/src/en/spyfakku/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'SpyFakku'
     extClass = '.SpyFakku'
-    extVersionCode = 10
+    extVersionCode = 11
     isNsfw = true
 }
 

--- a/src/en/spyfakku/src/eu/kanade/tachiyomi/extension/en/spyfakku/SpyFakku.kt
+++ b/src/en/spyfakku/src/eu/kanade/tachiyomi/extension/en/spyfakku/SpyFakku.kt
@@ -41,7 +41,7 @@ class SpyFakku : HttpSource() {
 
     override val lang = "en"
 
-    override val supportsLatest = false
+    override val supportsLatest = true
 
     private val json: Json by injectLazy()
 
@@ -59,6 +59,10 @@ class SpyFakku : HttpSource() {
         return GET("$baseApiUrl/library?sort=released_at&page=$page", headers)
     }
 
+    override fun latestUpdatesRequest(page: Int): Request {
+        return GET("$baseApiUrl/library?sort=created_at&page=$page", headers)
+    }
+
     override fun popularMangaParse(response: Response): MangasPage {
         val library = response.parseAs<HentaiLib>()
 
@@ -68,6 +72,8 @@ class SpyFakku : HttpSource() {
 
         return MangasPage(mangas, hasNextPage)
     }
+
+    override fun latestUpdatesParse(response: Response) = popularMangaParse(response)
 
     override fun searchMangaParse(response: Response) = popularMangaParse(response)
 
@@ -356,6 +362,6 @@ class SpyFakku : HttpSource() {
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
-    override fun latestUpdatesRequest(page: Int): Request = throw UnsupportedOperationException()
-    override fun latestUpdatesParse(response: Response) = throw UnsupportedOperationException()
+
+    override val supportsRelatedMangas = false
 }


### PR DESCRIPTION
Update the SpyFakku extension to support fetching the latest updates and increment the version code.

## Summary by Sourcery

Enable latest updates browsing, disable related manga support, and bump the extension version code

New Features:
- Enable latest updates browsing by setting supportsLatest to true and implementing latestUpdatesRequest and latestUpdatesParse

Enhancements:
- Disable related manga support by setting supportsRelatedMangas to false

Build:
- Bump extension version code from 10 to 11