### PR TITLE
feat(SpyFakku): add configurable domain preference

### DIFF
--- a/src/en/spyfakku/build.gradle
+++ b/src/en/spyfakku/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    kmkVersionCode = 1
     extName = 'SpyFakku'
     extClass = '.SpyFakku'
     extVersionCode = 11

--- a/src/en/spyfakku/src/eu/kanade/tachiyomi/extension/en/spyfakku/SpyFakku.kt
+++ b/src/en/spyfakku/src/eu/kanade/tachiyomi/extension/en/spyfakku/SpyFakku.kt
@@ -385,7 +385,7 @@ class SpyFakku : HttpSource(), ConfigurableSource {
             setDefaultValue(PREF_DOMAIN_DEFAULT)
             summary = "%s"
 
-            setOnPreferenceChangeListener { _, newValue ->
+            setOnPreferenceChangeListener { _, _ ->
                 Toast.makeText(screen.context, "Restart App to apply changes", Toast.LENGTH_LONG).show()
                 true
             }

--- a/src/en/spyfakku/src/eu/kanade/tachiyomi/extension/en/spyfakku/SpyFakku.kt
+++ b/src/en/spyfakku/src/eu/kanade/tachiyomi/extension/en/spyfakku/SpyFakku.kt
@@ -1,7 +1,11 @@
 package eu.kanade.tachiyomi.extension.en.spyfakku
 
+import android.widget.Toast
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -9,6 +13,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.getPreferences
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -29,17 +34,19 @@ import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 import kotlin.random.Random
 
-class SpyFakku : HttpSource() {
+class SpyFakku : HttpSource(), ConfigurableSource {
 
     override val name = "SpyFakku"
 
-    override val baseUrl = "https://hentalk.pw"
+    override val lang = "en"
+
+    private val preferences = getPreferences()
+
+    override val baseUrl = getPrefBaseUrl()
 
     private val baseImageUrl = "$baseUrl/image"
 
     private val baseApiUrl = "$baseUrl/api"
-
-    override val lang = "en"
 
     override val supportsLatest = true
 
@@ -364,4 +371,35 @@ class SpyFakku : HttpSource() {
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 
     override val supportsRelatedMangas = false
+
+    // ============================== Settings ==============================
+
+    private fun getPrefBaseUrl(): String = preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT) ?: PREF_DOMAIN_DEFAULT
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        ListPreference(screen.context).apply {
+            key = PREF_DOMAIN_KEY
+            title = "Preferred domain"
+            entries = DOMAINS
+            entryValues = DOMAINS
+            setDefaultValue(PREF_DOMAIN_DEFAULT)
+            summary = "%s"
+
+            setOnPreferenceChangeListener { _, newValue ->
+                val selected = newValue as String
+                Toast.makeText(screen.context, "Restart App to apply changes", Toast.LENGTH_LONG).show()
+                preferences.edit().putString(key, selected).apply()
+                true
+            }
+        }.also(screen::addPreference)
+    }
+
+    companion object {
+        private const val PREF_DOMAIN_KEY = "preferred_domain"
+        private val DOMAINS = arrayOf(
+            "https://fakku.cc",
+            "https://hentalk.pw",
+        )
+        private val PREF_DOMAIN_DEFAULT = DOMAINS[0]
+    }
 }

--- a/src/en/spyfakku/src/eu/kanade/tachiyomi/extension/en/spyfakku/SpyFakku.kt
+++ b/src/en/spyfakku/src/eu/kanade/tachiyomi/extension/en/spyfakku/SpyFakku.kt
@@ -295,7 +295,7 @@ class SpyFakku : HttpSource(), ConfigurableSource {
                     name = "Chapter"
                     url = manga.url
                     date_upload = try {
-                        releasedAtFormat.parse(add.released_at)!!.time
+                        add.released_at?.let { releasedAtFormat.parse(it) }!!.time
                     } catch (e: Exception) {
                         0L
                     }
@@ -374,7 +374,7 @@ class SpyFakku : HttpSource(), ConfigurableSource {
 
     // ============================== Settings ==============================
 
-    private fun getPrefBaseUrl(): String = preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT) ?: PREF_DOMAIN_DEFAULT
+    private fun getPrefBaseUrl(): String = preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!!
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         ListPreference(screen.context).apply {
@@ -386,9 +386,7 @@ class SpyFakku : HttpSource(), ConfigurableSource {
             summary = "%s"
 
             setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
                 Toast.makeText(screen.context, "Restart App to apply changes", Toast.LENGTH_LONG).show()
-                preferences.edit().putString(key, selected).apply()
                 true
             }
         }.also(screen::addPreference)

--- a/src/en/spyfakku/src/eu/kanade/tachiyomi/extension/en/spyfakku/SpyFakku.kt
+++ b/src/en/spyfakku/src/eu/kanade/tachiyomi/extension/en/spyfakku/SpyFakku.kt
@@ -13,7 +13,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import eu.kanade.tachiyomi.source.online.HttpSource
-import keiyoushi.utils.getPreferences
+import keiyoushi.utils.getPreferencesLazy
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -40,7 +40,7 @@ class SpyFakku : HttpSource(), ConfigurableSource {
 
     override val lang = "en"
 
-    private val preferences = getPreferences()
+    private val preferences by getPreferencesLazy()
 
     override val baseUrl = getPrefBaseUrl()
 


### PR DESCRIPTION
Introduce a preference setting that allows users to select their preferred domain for the SpyFakku extension, enhancing customization and usability.

## Summary by Sourcery

Enable domain customization for the SpyFakku extension by introducing a ListPreference setting to select and store the base URL, improve release date parsing safety, and update the build configuration.

New Features:
- Add configurable domain preference allowing users to select the SpyFakku extension domain via the settings screen

Bug Fixes:
- Safely handle missing chapter release dates to prevent null pointer errors

Enhancements:
- Refactor the base URL retrieval to use user preferences and implement ConfigurableSource

Build:
- Add kmkVersionCode property to build.gradle