### PR TITLE
feat(MissKon): request all pages async into one gallery

### DIFF
--- a/src/all/misskon/build.gradle
+++ b/src/all/misskon/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    kmkVersionCode = 9
+    kmkVersionCode = 10
     extName = 'MissKon (MrCong)'
     extClass = '.MissKon'
     extVersionCode = 2

--- a/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
+++ b/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
@@ -192,7 +192,7 @@ class MissKon : ConfigurableSource, ParsedHttpSource() {
 
     private suspend fun pageListParseAsync(document: Document): List<Page> {
         val pages = document
-            .select("div.page-link:first-child a")
+            .select("div.page-link:first-of-type a")
             .mapNotNull {
                 it.absUrl("href")
             }

--- a/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
+++ b/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
@@ -215,7 +215,7 @@ class MissKon : ConfigurableSource, ParsedHttpSource() {
     override fun pageListParse(document: Document) = throw UnsupportedOperationException()
 
     private fun parseImageList(document: Document): List<String> = document
-        .select("div.entry p img").map { image ->
+        .select("div.post-inner > div.entry > p > img").map { image ->
             image.imgAttr()
         }
 

--- a/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
+++ b/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
@@ -18,6 +18,9 @@ import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.tryParse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
@@ -169,22 +172,52 @@ class MissKon : ConfigurableSource, ParsedHttpSource() {
                             ?: YEAR_MONTH_REGEX.find(url)?.groupValues?.get(1)?.let { "$it/01" }
                     }
 
-                val dateUpload = FULL_DATE_FORMAT.tryParse(dateStr)
-                val maxPage = document.select("div.page-link:first-of-type a.post-page-numbers").last()?.text()?.toInt() ?: 1
-                return (maxPage downTo 1).map { page ->
+                return listOf(
                     SChapter.create().apply {
-                        setUrlWithoutDomain("${manga.url}/$page")
-                        name = "Page $page"
-                        date_upload = dateUpload
-                    }
-                }
+                        chapter_number = 0F
+                        setUrlWithoutDomain(manga.url)
+                        name = "Gallery"
+                        date_upload = FULL_DATE_FORMAT.tryParse(dateStr)
+                    },
+                )
             }
     }
 
-    override fun pageListParse(document: Document): List<Page> {
-        return document.select("div.post-inner > div.entry > p > img")
-            .mapIndexed { i, imgEl -> Page(i, imageUrl = imgEl.imgAttr()) }
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        return client.newCall(pageListRequest(chapter))
+            .execute().use { response ->
+                pageListParseAsync(response.asJsoup())
+            }
     }
+
+    private suspend fun pageListParseAsync(document: Document): List<Page> {
+        val pages = document
+            .select("div.page-link:first-child a")
+            .mapNotNull {
+                it.absUrl("href")
+            }
+
+        val chapterPage = parseImageList(document).toMutableList()
+
+        coroutineScope {
+            chapterPage += pages.map { url ->
+                async(Dispatchers.IO) {
+                    val request = GET(url, headers)
+                    parseImageList(client.newCall(request).execute().asJsoup())
+                }
+            }.awaitAll().flatten()
+        }
+
+        return chapterPage.mapIndexed { index, url ->
+            Page(index, imageUrl = url)
+        }
+    }
+    override fun pageListParse(document: Document) = throw UnsupportedOperationException()
+
+    private fun parseImageList(document: Document): List<String> = document
+        .select("div.entry p img").map { image ->
+            image.imgAttr()
+        }
 
     override fun imageUrlParse(document: Document) = throw UnsupportedOperationException()
 


### PR DESCRIPTION
Implement asynchronous requests to fetch all pages in a single gallery

## Summary by Sourcery

Implement asynchronous fetching of gallery pages and consolidate them into a single "Gallery" chapter

New Features:
- Concurrently fetch and parse all pages of a gallery using coroutines and aggregate them into one SChapter

Build:
- Bump kmkVersionCode from 9 to 10