### PR TITLE
chore(workflow): Adjust auto cherry-pick schedule times

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -2,10 +2,10 @@ name: Auto cherry-pick Keiyoushi
 
 on:
   schedule:
-    - cron: "0 0 * * *"
-    - cron: "0 6 * * *"
-    - cron: "0 12 * * *"
-    - cron: "0 18 * * *"
+    - cron: "0 2 * * *"
+    - cron: "0 8 * * *"
+    - cron: "0 14 * * *"
+    - cron: "0 20 * * *"
   workflow_dispatch: # Manual dispatch
 
 concurrency:


### PR DESCRIPTION
Update the cron schedule for the auto cherry-pick workflow to run at different times throughout the day.

## Summary by Sourcery

CI:
- update auto cherry-pick workflow schedule to new cron times