### PR TITLE
Add --keep-redundant-commits option to cherry-pick in auto_cherry_pick workflow

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -60,7 +60,7 @@ jobs:
           for (( i=${#upcoming_changes_hash[@]}; i>=0; i-- )); do
             if [ ! -z "${upcoming_changes_hash[i]}" -a "${upcoming_changes_hash[i]}" != " " ]; then
               echo "[$i]: Cherry picking '${upcoming_changes_hash[i]}'"
-              git cherry-pick --allow-empty "${upcoming_changes_hash[i]}"
+              git cherry-pick --allow-empty --keep-redundant-commits "${upcoming_changes_hash[i]}"
               latest_hash=${upcoming_changes_hash[i]}
             else
               echo "[$i]: skip '${upcoming_changes_hash[i]}'"


### PR DESCRIPTION
Introduce the `--keep-redundant-commits` option to the cherry-pick command in the auto_cherry_pick workflow to enhance commit handling.

## Summary by Sourcery

CI:
- Add `--keep-redundant-commits` option to git cherry-pick in auto_cherry_pick workflow