### PR TITLE
feat(Atsumaru): add recommendations

### DIFF
--- a/src/en/atsumaru/build.gradle
+++ b/src/en/atsumaru/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    kmkVersionCode = 1
     extName = 'Atsumaru'
     extClass = '.Atsumaru'
     extVersionCode = 5

--- a/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Atsumaru.kt
+++ b/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Atsumaru.kt
@@ -95,6 +95,12 @@ class Atsumaru : HttpSource() {
         return response.parseAs<MangaObjectDto>().mangaPage.toSManga(baseUrl)
     }
 
+    override fun relatedMangaListRequest(manga: SManga) = mangaDetailsRequest(manga)
+
+    override fun relatedMangaListParse(response: Response): List<SManga> {
+        return response.parseAs<MangaObjectDto>().mangaPage.recommendations(baseUrl)
+    }
+
     // ============================== Chapters ==============================
 
     private fun fetchChaptersRequest(mangaId: String, page: Int): Request {

--- a/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Dto.kt
+++ b/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Dto.kt
@@ -62,6 +62,8 @@ class MangaDto(
 
     // Chapters
     val chapters: List<ChapterDto>? = null,
+
+    val recommendations: List<MangaDto>? = null,
 ) {
     private fun getImagePath(): String? {
         val url = when (imagePath) {
@@ -91,6 +93,10 @@ class MangaDto(
                 else -> SManga.UNKNOWN
             }
         }
+    }
+
+    fun recommendations(baseUrl: String): List<SManga> {
+        return recommendations?.map { it.toSManga(baseUrl) } ?: emptyList()
     }
 
     @Serializable


### PR DESCRIPTION
Close #243

## Summary by Sourcery

Add support for fetching and displaying manga recommendations in the Atsumaru extension by wiring relatedMangaList endpoints and extending the MangaDto, and bump the extension’s kmkVersionCode.

New Features:
- Implement relatedMangaListRequest and relatedMangaListParse to fetch recommendations.
- Add a recommendations field and mapper function in MangaDto to convert recommended manga to SManga objects.

Build:
- Increment kmkVersionCode to 1 in build.gradle.