### PR TITLE
feat(buondua): update chapter and page retrieval to use `await` instead of `execute`

### DIFF
--- a/src/all/buondua/build.gradle
+++ b/src/all/buondua/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    kmkVersionCode = 1
+    kmkVersionCode = 2
     extName = 'Buon Dua'
     extClass = '.BuonDua'
     extVersionCode = 6

--- a/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
+++ b/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
@@ -215,13 +215,14 @@ class MissKon : ConfigurableSource, ParsedHttpSource() {
         }
     }
 
+    private val imageListSelector = "div.post-inner > div.entry > p > img"
     private fun parseImageList(document: Document): List<String> =
-        document.select("div.post-inner > div.entry > p > img")
+        document.select(imageListSelector)
             .map { it.imgAttr() }
 
     override fun pageListParse(document: Document): List<Page> {
-        return parseImageList(document)
-            .mapIndexed { i, img -> Page(i, imageUrl = img) }
+        return document.select(imageListSelector)
+            .mapIndexed { i, img -> Page(i, imageUrl = img.imgAttr()) }
     }
 
     private suspend fun pageListMerge(document: Document): List<Page> {


### PR DESCRIPTION
Streamline chapter and page retrieval by replacing synchronous calls with asynchronous `await` and renaming parsing functions for clarity. Update version code to reflect changes.

## Summary by Sourcery

Migrate BuonDua extension to suspend-based HTTP calls using await, rename parsing functions for clarity, adjust URL construction, extract common selector in MissKon, and bump kmkVersionCode

Enhancements:
- Use await on BuonDua network calls instead of execute and override suspend methods
- Rename BuonDua parsing functions for clarity (pageListParseAsync → pageListMerge)
- Refactor BuonDua chapter list URL construction to use baseUrl and manga.url
- Extract imageListSelector in MissKon and simplify page list parsing

Build:
- Bump BuonDua kmkVersionCode to 2