### PR TITLE
Add HangTruyen

### DIFF
--- a/src/vi/hangtruyen/build.gradle
+++ b/src/vi/hangtruyen/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    kmkVersionCode = 1
     extName = 'HangTruyen'
     extClass = '.HangTruyen'
     extVersionCode = 1

--- a/src/vi/hangtruyen/src/eu/kanade/tachiyomi/extension/vi/hangtruyen/HangTruyen.kt
+++ b/src/vi/hangtruyen/src/eu/kanade/tachiyomi/extension/vi/hangtruyen/HangTruyen.kt
@@ -146,6 +146,9 @@ class HangTruyen : ParsedHttpSource(), ConfigurableSource {
         thumbnail_url = element.selectFirst("img")?.attr("abs:data-src")
     }
 
+    // Related
+    override fun relatedMangaListSelector() = "#cm-related ul.list-unstyled > li"
+
     // Details
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {
         title = document.selectFirst("h1.title-detail a")!!.text()


### PR DESCRIPTION
## Summary by Sourcery

Add a new HangTruyen extension as a Vietnamese manga source with full browsing, search, and reading capabilities.

New Features:
- Introduce HangTruyen extension with support for popular, latest, search, details, chapters, and page parsing.

Enhancements:
- Add configurable base URL override with automatic redirect detection and storage.
- Implement dynamic filters including sort options, genres (fetched from site metadata), and categories.
- Add custom date parsing to handle Vietnamese relative and absolute time formats.

Build:
- Include build configuration for the HangTruyen extension with versioning and NSFW flag.