### PR TITLE
chore(workflow): Auto cherry-pick every 3 hours

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -3,9 +3,13 @@ name: Auto cherry-pick Keiyoushi
 on:
   schedule:
     - cron: "0 2 * * *"
+    - cron: "0 5 * * *"
     - cron: "0 8 * * *"
+    - cron: "0 11 * * *"
     - cron: "0 14 * * *"
+    - cron: "0 17 * * *"
     - cron: "0 20 * * *"
+    - cron: "0 23 * * *"
   workflow_dispatch: # Manual dispatch
 
 concurrency:


### PR DESCRIPTION
Extend the schedule for the auto cherry-pick workflow to run every 3 hours, adding additional cron jobs for more frequent execution.

## Summary by Sourcery

CI:
- Increase the auto cherry-pick GitHub Actions workflow frequency by adding additional scheduled cron runs.