### PR TITLE
Madara: Add related manga support to Madara and clean up related manga methods in other sources

### DIFF
--- a/lib-multisrc/madara/build.gradle.kts
+++ b/lib-multisrc/madara/build.gradle.kts
@@ -1,3 +1,5 @@
+kmkBaseVersionCode = 1
+
 plugins {
     id("lib-multisrc")
 }

--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -196,6 +196,21 @@ abstract class Madara(
             "div.nav-previous, nav.navigation-ajax, a.nextpostslink"
         }
 
+    // Related Manga
+    override fun relatedMangaListSelector() = ".related-reading-wrap"
+
+    override fun relatedMangaFromElement(element: Element): SManga {
+        return SManga.create().apply {
+            element.selectFirst(".widget-title a")!!.let {
+                setUrlWithoutDomain(it.attr("abs:href"))
+                title = it.ownText()
+            }
+            element.selectFirst(".widget-thumbnail img")?.let {
+                thumbnail_url = imageFromElement(it)
+            }
+        }
+    }
+
     // Latest Updates
 
     override fun latestUpdatesSelector() = popularMangaSelector()

--- a/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
+++ b/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
@@ -17,7 +17,6 @@ import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.utils.getPreferences
 import org.jsoup.nodes.Document
-import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -111,20 +110,6 @@ class Hiperdex :
         }.also { screen.addPreference(it) }
 
         addRandomUAPreferenceToScreen(screen)
-    }
-
-    override fun relatedMangaListSelector() = ".related-reading-wrap"
-
-    override fun relatedMangaFromElement(element: Element): SManga {
-        return SManga.create().apply {
-            element.selectFirst(".widget-title a")!!.let {
-                setUrlWithoutDomain(it.attr("abs:href"))
-                title = it.ownText()
-            }
-            element.selectFirst(".widget-thumbnail img")?.let {
-                thumbnail_url = imageFromElement(it)
-            }
-        }
     }
 
     override fun searchMangaSelector() = "#loop-content div.page-listing-item"

--- a/src/en/mangadistrict/build.gradle
+++ b/src/en/mangadistrict/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    kmkVersionCode = 2
+    kmkVersionCode = 1
     extName = 'Manga District'
     extClass = '.MangaDistrict'
     themePkg = 'madara'

--- a/src/en/mangadistrict/src/eu/kanade/tachiyomi/extension/en/mangadistrict/MangaDistrict.kt
+++ b/src/en/mangadistrict/src/eu/kanade/tachiyomi/extension/en/mangadistrict/MangaDistrict.kt
@@ -372,25 +372,6 @@ class MangaDistrict :
         }
     }
 
-    override fun relatedMangaListSelector() = ".related-manga .related-reading-wrap"
-
-    override fun relatedMangaFromElement(element: Element): SManga {
-        val manga = SManga.create()
-
-        with(element) {
-            selectFirst(".related-reading-content a")!!.let {
-                manga.setUrlWithoutDomain(it.attr("abs:href"))
-                manga.title = it.ownText()
-            }
-
-            selectFirst("img")?.let {
-                manga.thumbnail_url = imageFromElement(it)
-            }
-        }
-
-        return manga
-    }
-
     companion object {
         private val titleRegex: Regex =
             Regex("\\([^()]*\\)|\\{[^{}]*\\}|\\[(?:(?!]).)*]|«[^»]*»|〘[^〙]*〙|「[^」]*」|『[^』]*』|≪[^≫]*≫|﹛[^﹜]*﹜|〖[^〖〗]*〗|\uD81A\uDD0D.+?\uD81A\uDD0D|《[^》]*》|⌜.+?⌝|⟨[^⟩]*⟩|/Official|/ Official", RegexOption.IGNORE_CASE)

--- a/src/en/manycomic/build.gradle
+++ b/src/en/manycomic/build.gradle
@@ -1,5 +1,4 @@
 ext {
-    kmkVersionCode = 1
     extName = 'ManyComic'
     extClass = '.ManyComic'
     themePkg = 'madara'

--- a/src/en/manycomic/src/eu/kanade/tachiyomi/extension/en/manycomic/ManyComic.kt
+++ b/src/en/manycomic/src/eu/kanade/tachiyomi/extension/en/manycomic/ManyComic.kt
@@ -5,12 +5,10 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
-import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import org.jsoup.nodes.Document
-import org.jsoup.nodes.Element
 
 class ManyComic : Madara("ManyComic", "https://manycomic.com", "en") {
     override val mangaSubString = "comic"
@@ -109,23 +107,4 @@ class ManyComic : Madara("ManyComic", "https://manycomic.com", "en") {
 
     private class GenreFilter(title: String, options: List<Genre>, state: Int = 0) :
         UriPartFilter(title, options.map { Pair(it.name, it.id) }.toTypedArray(), state)
-
-    override fun relatedMangaListSelector() = ".related-manga .related-reading-wrap"
-
-    override fun relatedMangaFromElement(element: Element): SManga {
-        val manga = SManga.create()
-
-        with(element) {
-            selectFirst(".related-reading-content .widget-title a")!!.let {
-                manga.setUrlWithoutDomain(it.attr("abs:href"))
-                manga.title = it.ownText()
-            }
-
-            selectFirst("img")?.let {
-                manga.thumbnail_url = imageFromElement(it)
-            }
-        }
-
-        return manga
-    }
 }

--- a/src/ko/manhwaraw/src/eu/kanade/tachiyomi/extension/ko/manhwaraw/ManhwaRaw.kt
+++ b/src/ko/manhwaraw/src/eu/kanade/tachiyomi/extension/ko/manhwaraw/ManhwaRaw.kt
@@ -220,23 +220,4 @@ class ManhwaRaw : Madara("ManhwaRaw", "https://manhwaraw.com", "ko") {
 
         return POST("$baseUrl/wp-admin/admin-ajax.php", xhrHeaders, form)
     }
-
-    override fun relatedMangaListSelector() = ".related-manga .related-reading-wrap"
-
-    override fun relatedMangaFromElement(element: Element): SManga {
-        val manga = SManga.create()
-
-        with(element) {
-            selectFirst(".widget-title a")!!.let {
-                manga.setUrlWithoutDomain(it.attr("abs:href"))
-                manga.title = it.ownText()
-            }
-
-            selectFirst("img")?.let {
-                manga.thumbnail_url = imageFromElement(it)
-            }
-        }
-
-        return manga
-    }
 }


### PR DESCRIPTION
## Summary by Sourcery

Centralize Madara-related manga handling and align individual Madara-based extensions with the shared implementation.

New Features:
- Add a shared related-manga implementation to the Madara multisrc base.

Enhancements:
- Remove custom related-manga parsing from Hiperdex, ManyComic, MangaDistrict, and ManhwaRaw in favor of the shared Madara implementation.

Build:
- Introduce a base version code for the Madara multisrc library and adjust MangaDistrict and ManyComic extension version codes accordingly.