### PR TITLE
Update AnimeSama extension to use new domain and increment version code

### DIFF
--- a/src/fr/animesama/AndroidManifest.xml
+++ b/src/fr/animesama/AndroidManifest.xml
@@ -14,7 +14,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="anime-sama.si"
+                    android:host="anime-sama.tv"
                     android:pathPattern="/catalogue/..*"
                     android:scheme="https" />
             </intent-filter>

--- a/src/fr/animesama/build.gradle
+++ b/src/fr/animesama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeSama'
     extClass = '.AnimeSama'
-    extVersionCode = 12
+    extVersionCode = 13
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSama.kt
@@ -30,7 +30,7 @@ class AnimeSama : ParsedHttpSource() {
 
     override val name = "AnimeSama"
 
-    override val baseUrl = "https://anime-sama.si"
+    override val baseUrl = "https://anime-sama.tv"
 
     private val cdn = "$baseUrl/s2/scans/"
 

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSamaUrlActivity.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSamaUrlActivity.kt
@@ -8,7 +8,7 @@ import android.util.Log
 import kotlin.system.exitProcess
 
 /**
- * Springboard that accepts https://anime-sama.si/catalogue/xxxxxx/ intents and redirects them to
+ * Springboard that accepts https://anime-sama.tv/catalogue/xxxxxx/ intents and redirects them to
  * the main Tachiyomi process.
  */
 class AnimeSamaUrlActivity : Activity() {


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

## Summary by Sourcery

Update the AnimeSama extension to use the new anime-sama.tv domain and release a new extension version.

Bug Fixes:
- Fix AnimeSama source and URL handling by pointing to the updated anime-sama.tv domain.

Build:
- Bump AnimeSama extension version code to 13 to publish the domain update.