### PR TITLE
Conditional cleanTitleIfNeeded on XBatCat, MangaDistrict, HiperDex

### DIFF
--- a/src/all/batoto/build.gradle
+++ b/src/all/batoto/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    kmkVersionCode = 1
     extName = 'XBatCat'
     extClass = '.XBatCatFactory'
     extVersionCode = 61

--- a/src/en/hiperdex/build.gradle
+++ b/src/en/hiperdex/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    kmkVersionCode = 1
+    kmkVersionCode = 2
     extName = 'Hiperdex'
     extClass = '.Hiperdex'
     themePkg = 'madara'

--- a/src/en/mangadistrict/build.gradle
+++ b/src/en/mangadistrict/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    kmkVersionCode = 1
+    kmkVersionCode = 2
     extName = 'Manga District'
     extClass = '.MangaDistrict'
     themePkg = 'madara'


### PR DESCRIPTION
## Summary by Sourcery

Add an option to disable automatic title cleaning in browsing and search results for XBatCat, Hiperdex, and MangaDistrict while keeping it for manga details.

New Features:
- Introduce a per-extension setting to skip title cleaning when browsing or searching manga entries in XBatCat, Hiperdex, and MangaDistrict.

Enhancements:
- Apply conditional title cleaning based on the new preference in popular, latest, and search result parsing for the affected extensions.

Build:
- Bump internal kmkVersionCode for the Hiperdex, MangaDistrict, and XBatCat extensions to reflect the new behavior.