### PR TITLE
Update `extensions-lib` version to v1.4.5.1 [b6fb731bf6]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ gradle-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", v
 
 spotless-gradle = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version = "8.4.0" }
 
-tachiyomi-lib = { module = "com.github.komikku-app:extensions-lib", version = "1.7.1" }
+tachiyomi-lib = { module = "com.github.komikku-app:extensions-lib", version = "b6fb731bf6" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "serialization" }


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the tachiyomi-lib (extensions-lib) dependency in the Gradle version catalog to use the new b6fb731bf6 version identifier.