### PR TITLE
KomikIndoID Fix

### DIFF
--- a/src/id/komikindoid/build.gradle
+++ b/src/id/komikindoid/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'KomikIndoID'
     extClass = '.KomikIndoID'
-    extVersionCode = 18
+    extVersionCode = 19
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/komikindoid/src/eu/kanade/tachiyomi/extension/id/komikindoid/KomikIndoID.kt
+++ b/src/id/komikindoid/src/eu/kanade/tachiyomi/extension/id/komikindoid/KomikIndoID.kt
@@ -3,20 +3,23 @@ package eu.kanade.tachiyomi.extension.id.komikindoid
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import eu.kanade.tachiyomi.source.online.HttpSource
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.Response
+import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 
-class KomikIndoID : ParsedHttpSource() {
+class KomikIndoID : HttpSource() {
     override val name = "KomikIndoID"
     override val baseUrl = "https://komikindo.ch"
     override val lang = "id"
@@ -29,21 +32,38 @@ class KomikIndoID : ParsedHttpSource() {
 
     override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/daftar-manga/page/$page/?order=update", headers)
 
-    override fun popularMangaSelector() = "div.animepost"
-    override fun latestUpdatesSelector() = popularMangaSelector()
-    override fun searchMangaSelector() = popularMangaSelector()
+    override fun popularMangaParse(response: Response): MangasPage {
+        val document = response.body.string().let { Jsoup.parse(it) }
+        val mangas = document.select("div.animepost").map { element ->
+            parseMangaFromElement(element)
+        }
+        val hasNextPage = document.selectFirst("a.next.page-numbers") != null
+        return MangasPage(mangas, hasNextPage)
+    }
 
-    override fun popularMangaFromElement(element: Element): SManga = searchMangaFromElement(element)
-    override fun latestUpdatesFromElement(element: Element): SManga = searchMangaFromElement(element)
+    override fun latestUpdatesParse(response: Response): MangasPage {
+        val document = response.body.string().let { Jsoup.parse(it) }
+        val mangas = document.select("div.animepost").map { element ->
+            parseMangaFromElement(element)
+        }
 
-    override fun popularMangaNextPageSelector() = "a.next.page-numbers"
-    override fun latestUpdatesNextPageSelector() = popularMangaNextPageSelector()
-    override fun searchMangaNextPageSelector() = popularMangaNextPageSelector()
+        val hasNextPage = document.selectFirst("a.next.page-numbers") != null
+        return MangasPage(mangas, hasNextPage)
+    }
 
-    override fun searchMangaFromElement(element: Element): SManga {
+    override fun searchMangaParse(response: Response): MangasPage {
+        val document = response.body.string().let { Jsoup.parse(it) }
+        val mangas = document.select("div.animepost").map { element ->
+            parseMangaFromElement(element)
+        }
+        val hasNextPage = document.selectFirst("a.next.page-numbers") != null
+        return MangasPage(mangas, hasNextPage)
+    }
+
+    private fun parseMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
         manga.thumbnail_url = element.select("div.limit img").attr("src")
-        manga.title = element.select("div.tt h4").text()
+        manga.title = element.select("div.tt h3").text()
         element.select("div.animposx > a").first()!!.let {
             manga.setUrlWithoutDomain(it.attr("href"))
         }
@@ -128,7 +148,13 @@ class KomikIndoID : ParsedHttpSource() {
         }
         return GET(url.build(), headers)
     }
-    override fun mangaDetailsParse(document: Document): SManga {
+
+    override fun mangaDetailsParse(response: Response): SManga {
+        val document = response.body.string().let { Jsoup.parse(it) }
+        return parseMangaDetails(document)
+    }
+
+    private fun parseMangaDetails(document: Document): SManga {
         val infoElement = document.select("div.infoanime").first()!!
         val descElement = document.select("div.desc > .entry-content.entry-content-single").first()!!
         val manga = SManga.create()
@@ -160,9 +186,14 @@ class KomikIndoID : ParsedHttpSource() {
         else -> SManga.UNKNOWN
     }
 
-    override fun chapterListSelector() = "#chapter_list li"
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val document = response.body.string().let { Jsoup.parse(it) }
+        return document.select("#chapter_list li").map { element ->
+            parseChapterFromElement(element)
+        }
+    }
 
-    override fun chapterFromElement(element: Element): SChapter {
+    private fun parseChapterFromElement(element: Element): SChapter {
         val urlElement = element.select(".lchx a").first()!!
         val chapter = SChapter.create()
         chapter.setUrlWithoutDomain(urlElement.attr("href"))
@@ -225,7 +256,12 @@ class KomikIndoID : ParsedHttpSource() {
         }
     }
 
-    override fun pageListParse(document: Document): List<Page> {
+    override fun pageListParse(response: Response): List<Page> {
+        val document = response.body.string().let { Jsoup.parse(it) }
+        return parsePageList(document)
+    }
+
+    private fun parsePageList(document: Document): List<Page> {
         val pages = mutableListOf<Page>()
         var i = 0
         document.select("div.img-landmine img").forEach { element ->
@@ -238,7 +274,7 @@ class KomikIndoID : ParsedHttpSource() {
         return pages
     }
 
-    override fun imageUrlParse(document: Document): String = throw UnsupportedOperationException()
+    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 
     override fun getFilterList() = FilterList(
         SortFilter(),

--- a/src/id/komikindoid/src/eu/kanade/tachiyomi/extension/id/komikindoid/KomikIndoID.kt
+++ b/src/id/komikindoid/src/eu/kanade/tachiyomi/extension/id/komikindoid/KomikIndoID.kt
@@ -8,11 +8,11 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
@@ -32,30 +32,15 @@ class KomikIndoID : HttpSource() {
 
     override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/daftar-manga/page/$page/?order=update", headers)
 
-    override fun popularMangaParse(response: Response): MangasPage {
-        val document = response.body.string().let { Jsoup.parse(it) }
-        val mangas = document.select("div.animepost").map { element ->
-            parseMangaFromElement(element)
-        }
-        val hasNextPage = document.selectFirst("a.next.page-numbers") != null
-        return MangasPage(mangas, hasNextPage)
-    }
+    override fun popularMangaParse(response: Response): MangasPage = mangasPageParse(response)
 
-    override fun latestUpdatesParse(response: Response): MangasPage {
-        val document = response.body.string().let { Jsoup.parse(it) }
-        val mangas = document.select("div.animepost").map { element ->
-            parseMangaFromElement(element)
-        }
+    override fun latestUpdatesParse(response: Response): MangasPage = mangasPageParse(response)
 
-        val hasNextPage = document.selectFirst("a.next.page-numbers") != null
-        return MangasPage(mangas, hasNextPage)
-    }
+    override fun searchMangaParse(response: Response): MangasPage = mangasPageParse(response)
 
-    override fun searchMangaParse(response: Response): MangasPage {
-        val document = response.body.string().let { Jsoup.parse(it) }
-        val mangas = document.select("div.animepost").map { element ->
-            parseMangaFromElement(element)
-        }
+    private fun mangasPageParse(response: Response): MangasPage {
+        val document = response.asJsoup()
+        val mangas = document.select("div.animepost").map(::parseMangaFromElement)
         val hasNextPage = document.selectFirst("a.next.page-numbers") != null
         return MangasPage(mangas, hasNextPage)
     }
@@ -150,7 +135,7 @@ class KomikIndoID : HttpSource() {
     }
 
     override fun mangaDetailsParse(response: Response): SManga {
-        val document = response.body.string().let { Jsoup.parse(it) }
+        val document = response.asJsoup()
         return parseMangaDetails(document)
     }
 
@@ -187,7 +172,7 @@ class KomikIndoID : HttpSource() {
     }
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val document = response.body.string().let { Jsoup.parse(it) }
+        val document = response.asJsoup()
         return document.select("#chapter_list li").map { element ->
             parseChapterFromElement(element)
         }
@@ -257,7 +242,7 @@ class KomikIndoID : HttpSource() {
     }
 
     override fun pageListParse(response: Response): List<Page> {
-        val document = response.body.string().let { Jsoup.parse(it) }
+        val document = response.asJsoup()
         return parsePageList(document)
     }
 


### PR DESCRIPTION
* Refactor to use HttpSource
* Update title selector
* Update parsing logic for manga, chapters, and pages

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

## Summary by Sourcery

Refactor the KomikIndoID extension to use HttpSource-based manual parsing and update selectors to match the current site structure.

Bug Fixes:
- Fix manga listing, details, chapter list, and page list parsing for KomikIndoID to reflect the site's updated HTML structure.

Enhancements:
- Unify popular, latest, and search manga parsing through shared helpers for list and detail pages in KomikIndoID.

Build:
- Bump KomikIndoID extension version code to 19.