### PR TITLE
fix komikdewasaart: reverse chapters

### DIFF
--- a/src/id/komikdewasaart/build.gradle
+++ b/src/id/komikdewasaart/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.KomikDewasaArt'
     themePkg = 'mangathemesia'
     baseUrl = 'https://komikdewasa.art'
-    overrideVersionCode = 0
+    overrideVersionCode = 31
     isNsfw = true
 }
 

--- a/src/id/komikdewasaart/src/eu/kanade/tachiyomi/extension/id/komikdewasaart/KomikDewasaArt.kt
+++ b/src/id/komikdewasaart/src/eu/kanade/tachiyomi/extension/id/komikdewasaart/KomikDewasaArt.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.extension.id.komikdewasaart
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.source.model.SChapter
+import okhttp3.Response
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -11,4 +13,6 @@ class KomikDewasaArt :
         "id",
         mangaUrlDirectory = "/komik",
         dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.ROOT),
-    )
+    ) {
+    override fun chapterListParse(response: Response): List<SChapter> = super.chapterListParse(response).reversed()
+}


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

## Summary by Sourcery

Bug Fixes:
- Fix KomikDewasaArt chapter listing by returning chapters in the opposite order from the base parser.