### PR TITLE
MadaraScans: add preference to show/hide premium chapters

### DIFF
--- a/src/en/madarascans/build.gradle
+++ b/src/en/madarascans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MadaraScans'
     themePkg = 'mangathemesia'
     baseUrl = 'https://madarascans.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/madarascans/src/eu/kanade/tachiyomi/extension/en/madarascans/MadaraScans.kt
+++ b/src/en/madarascans/src/eu/kanade/tachiyomi/extension/en/madarascans/MadaraScans.kt
@@ -1,13 +1,18 @@
 package eu.kanade.tachiyomi.extension.en.madarascans
 
+import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import keiyoushi.utils.getPreferencesLazy
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
+import kotlin.getValue
 
 class MadaraScans :
     MangaThemesia(
@@ -16,7 +21,11 @@ class MadaraScans :
         "en",
         mangaUrlDirectory = "/series",
         dateFormat = SimpleDateFormat("yyyy/MM/dd", Locale.US),
-    ) {
+    ),
+    ConfigurableSource {
+
+    private val preferences by getPreferencesLazy()
+
     // support for both popular/latest tabs and search
     override fun searchMangaSelector() = "div.listupd>div, div.legend-inner"
 
@@ -37,15 +46,30 @@ class MadaraScans :
     override val seriesStatusSelector = "span.status-badge-lux"
     override val seriesThumbnailSelector = ".lh-poster > img"
 
-    // limiting chapters to free
-    override fun chapterListSelector(): String = ".ch-item.free"
+    override fun chapterListSelector(): String {
+        return if (preferences.getBoolean(PREF_HIDE_PREMIUM_CHAPTERS, true)) {
+            ".ch-item.free"
+        } else {
+            ".ch-item"
+        }
+    }
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         val urlElements = element.select("a")
         setUrlWithoutDomain(urlElements.attr("href"))
-        name = element.select(".ch-num").text().ifBlank { urlElements.first()!!.text() }
+        val chapterName = element.select(".ch-num").text().ifBlank { urlElements.first()!!.text() }
+        name = if (!element.hasClass("free")) "🔒 $chapterName" else chapterName
         val dateElement = element.select(".ch-date")?.text()
         date_upload = dateElement.parseChapterDate()
+    }
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        SwitchPreferenceCompat(screen.context).apply {
+            key = PREF_HIDE_PREMIUM_CHAPTERS
+            title = "Hide premium chapters"
+            summary = "Turn off to show premium chapters in the chapter list"
+            setDefaultValue(true)
+        }.also(screen::addPreference)
     }
 
     override fun getFilterList(): FilterList {
@@ -81,4 +105,8 @@ class MadaraScans :
     }
 
     override val pageSelector = ".pagination, .legendary-pagination, .magma-pagination"
+
+    companion object {
+        private const val PREF_HIDE_PREMIUM_CHAPTERS = "pref_hide_premium_chapters"
+    }
 }

--- a/src/en/madarascans/src/eu/kanade/tachiyomi/extension/en/madarascans/MadaraScans.kt
+++ b/src/en/madarascans/src/eu/kanade/tachiyomi/extension/en/madarascans/MadaraScans.kt
@@ -57,7 +57,7 @@ class MadaraScans :
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         val urlElements = element.select("a")
         setUrlWithoutDomain(urlElements.attr("href"))
-        val chapterName = element.select(".ch-num").text().ifBlank { urlElements.first()!!.text() }
+        val chapterName = element.select(".ch-num").text().ifBlank { urlElements.firstOrNull()?.text().orEmpty() }
         name = if (!element.hasClass("free")) "🔒 $chapterName" else chapterName
         val dateElement = element.select(".ch-date")?.text()
         date_upload = dateElement.parseChapterDate()

--- a/src/en/madarascans/src/eu/kanade/tachiyomi/extension/en/madarascans/MadaraScans.kt
+++ b/src/en/madarascans/src/eu/kanade/tachiyomi/extension/en/madarascans/MadaraScans.kt
@@ -46,12 +46,10 @@ class MadaraScans :
     override val seriesStatusSelector = "span.status-badge-lux"
     override val seriesThumbnailSelector = ".lh-poster > img"
 
-    override fun chapterListSelector(): String {
-        return if (preferences.getBoolean(PREF_HIDE_PREMIUM_CHAPTERS, true)) {
-            ".ch-item.free"
-        } else {
-            ".ch-item"
-        }
+    override fun chapterListSelector(): String = if (preferences.getBoolean(PREF_HIDE_PREMIUM_CHAPTERS, true)) {
+        ".ch-item.free"
+    } else {
+        ".ch-item"
     }
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

## Summary by Sourcery

Add a configurable option for MadaraScans to control visibility and labeling of premium chapters.

New Features:
- Introduce a user preference to hide or show premium chapters in the MadaraScans extension.
- Display a lock indicator in chapter titles for non-free (premium) chapters when they are shown.

Enhancements:
- Update the MadaraScans extension version code to reflect the new behavior.