### PR TITLE
Fix Discord link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,7 +206,7 @@ and [negative refspecs](https://github.blog/2020-10-19-git-2-29-released/#user-c
 
 ## Getting help
 
-- Join [the Discord server](https://discord.gg/3FbCpdKbdY) for online help and to ask questions while
+- Join [the Discord server](https://discord.gg/85MZhUX688) for online help and to ask questions while
 developing your extension. When doing so, please ask them in the `#programming` channel.
 - There are some features and tricks that are not explored in this document. Refer to existing
 extension code for examples.


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the CONTRIBUTING guide to use the new Discord invite URL for community support.