### PR TITLE
Change base URL for Team Lanh Lung extension

### DIFF
--- a/src/vi/teamlanhlung/src/eu/kanade/tachiyomi/extension/vi/teamlanhlung/TeamLanhLung.kt
+++ b/src/vi/teamlanhlung/src/eu/kanade/tachiyomi/extension/vi/teamlanhlung/TeamLanhLung.kt
@@ -28,7 +28,7 @@ class TeamLanhLung : HttpSource() {
 
     override val name: String = "Team Lạnh Lùng"
 
-    override val baseUrl: String = "https://nhalung.top"
+    override val baseUrl: String = "https://lunghihi.icu"
 
     override val lang: String = "vi"
 


### PR DESCRIPTION
Update the Team Lanh Lung extension to use the new website domain and bump its extension version code.

Bug Fixes:

Point the Team Lanh Lung source to the updated base URL to restore connectivity.
Build:

Increment the Team Lanh Lung extension version code to reflect the domain change.

## Summary by Sourcery

Bug Fixes:
- Point the Team Lạnh Lùng source to the new base URL to restore connectivity to the site.