### PR TITLE
Change base URL for Team Lanh Lung extension

### DIFF
--- a/src/vi/teamlanhlung/build.gradle
+++ b/src/vi/teamlanhlung/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Team Lanh Lung'
     extClass = '.TeamLanhLung'
-    extVersionCode = 30
+    extVersionCode = 31
     isNsfw = true
 }
 

--- a/src/vi/teamlanhlung/src/eu/kanade/tachiyomi/extension/vi/teamlanhlung/TeamLanhLung.kt
+++ b/src/vi/teamlanhlung/src/eu/kanade/tachiyomi/extension/vi/teamlanhlung/TeamLanhLung.kt
@@ -28,7 +28,7 @@ class TeamLanhLung : HttpSource() {
 
     override val name: String = "Team Lạnh Lùng"
 
-    override val baseUrl: String = "https://nhalung.top"
+    override val baseUrl: String = "https://lunghihi.icu"
 
     override val lang: String = "vi"
 


### PR DESCRIPTION
## Summary by Sourcery

Update the Vietnamese Team Lanh Lung extension to use the new site domain and reflect the change in its versioning.

Bug Fixes:
- Restore connectivity for the Team Lanh Lung source by pointing it to the updated base URL.

Build:
- Bump the Team Lanh Lung extension version code to account for the domain update.