### PR TITLE
fix(id/kumapoi): prevent detail parser crash

### DIFF
--- a/src/id/kumapoi/build.gradle
+++ b/src/id/kumapoi/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.KumaPoi'
     themePkg = 'mangathemesia'
     baseUrl = 'https://kumapoi.info'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
     isNsfw = true
 }
 

--- a/src/id/kumapoi/src/eu/kanade/tachiyomi/extension/id/kumapoi/KumaPoi.kt
+++ b/src/id/kumapoi/src/eu/kanade/tachiyomi/extension/id/kumapoi/KumaPoi.kt
@@ -2,12 +2,63 @@ package eu.kanade.tachiyomi.extension.id.kumapoi
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.OkHttpClient
+import okhttp3.Response
+import org.jsoup.nodes.Document
+import java.text.SimpleDateFormat
+import java.util.Locale
 
-class KumaPoi : MangaThemesia("KumaPoi", "https://kumapoi.info", "id") {
+class KumaPoi :
+    MangaThemesia(
+        "KumaPoi",
+        "https://kumapoi.info",
+        "id",
+        dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.forLanguageTag("id")),
+    ) {
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(4)
         .build()
 
     override val hasProjectPage = true
+
+    // override fun mangaDetailsParse(response: Response): SManga = mangaDetailsParse(response.asJsoup())
+
+    override fun mangaDetailsParse(document: Document) = SManga.create().apply {
+        val seriesDetails = document.selectFirst(seriesDetailsSelector)
+        val pageTitle = document.title().substringBefore(" - ").trim()
+
+        if (seriesDetails == null) {
+            title = pageTitle
+            return@apply
+        }
+
+        title = seriesDetails.selectFirst(seriesTitleSelector)?.text().takeIf { it.isNullOrBlank().not() }
+            ?: pageTitle
+        artist = seriesDetails.selectFirst(seriesArtistSelector)?.ownText().removeEmptyPlaceholder()
+        author = seriesDetails.selectFirst(seriesAuthorSelector)?.ownText().removeEmptyPlaceholder()
+        description = seriesDetails.select(seriesDescriptionSelector).joinToString("\n") { it.text() }.trim()
+
+        val altName = seriesDetails.selectFirst(seriesAltNameSelector)?.ownText().takeIf { it.isNullOrBlank().not() }
+        altName?.let {
+            description = "$description\n\n$altNamePrefix$altName".trim()
+        }
+
+        val genres = seriesDetails.select(seriesGenreSelector).map { it.text() }.toMutableList()
+        seriesDetails.selectFirst(seriesTypeSelector)?.ownText().takeIf { it.isNullOrBlank().not() }?.let { genres.add(it) }
+        genre = genres.map { genre ->
+            genre.lowercase(Locale.forLanguageTag(lang)).replaceFirstChar { char ->
+                if (char.isLowerCase()) {
+                    char.titlecase(Locale.forLanguageTag(lang))
+                } else {
+                    char.toString()
+                }
+            }
+        }.joinToString { it.trim() }
+
+        status = seriesDetails.selectFirst(seriesStatusSelector)?.text().parseStatus()
+        thumbnail_url = seriesDetails.select(seriesThumbnailSelector).firstOrNull()?.imgAttr()
+            ?: document.selectFirst("meta[property=og:image]")?.attr("content")
+    }
 }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

## Summary by Sourcery

Update the KumaPoi extension to use a custom, more robust manga details parser and bump its override version code.

Bug Fixes:
- Prevent crashes when parsing manga details on KumaPoi by handling missing or malformed series details more defensively.

Enhancements:
- Customize the KumaPoi details parsing to extract titles, creators, description, genres, status, and thumbnail using site-specific selectors and localized date formatting.

Build:
- Increment the KumaPoi extension overrideVersionCode to publish the updated parser.