### PR TITLE
Xinmeitulu `ParsedHttpSource` to `HttpSource`

### DIFF
--- a/src/all/xinmeitulu/AndroidManifest.xml
+++ b/src/all/xinmeitulu/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <application>
         <activity
-            android:name=".all.xinmeitulu.XinmeituluUrlActivity"
+            android:name=".all.xinmeitulu.UrlActivity"
             android:excludeFromRecents="true"
             android:exported="true"
             android:theme="@android:style/Theme.NoDisplay">

--- a/src/all/xinmeitulu/build.gradle
+++ b/src/all/xinmeitulu/build.gradle
@@ -2,7 +2,7 @@ ext {
     kmkVersionCode = 3
     extName = 'Xinmeitulu'
     extClass = '.Xinmeitulu'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/all/xinmeitulu/build.gradle
+++ b/src/all/xinmeitulu/build.gradle
@@ -2,7 +2,7 @@ ext {
     kmkVersionCode = 3
     extName = 'Xinmeitulu'
     extClass = '.Xinmeitulu'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/all/xinmeitulu/build.gradle
+++ b/src/all/xinmeitulu/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    kmkVersionCode = 3
+    kmkVersionCode = 2
     extName = 'Xinmeitulu'
     extClass = '.Xinmeitulu'
     extVersionCode = 7

--- a/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/UrlActivity.kt
+++ b/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/UrlActivity.kt
@@ -7,7 +7,7 @@ import android.os.Bundle
 import android.util.Log
 import kotlin.system.exitProcess
 
-class XinmeituluUrlActivity : Activity() {
+class UrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -18,7 +18,7 @@ class XinmeituluUrlActivity : Activity() {
             val query = fromUrl(pathSegments)
 
             if (query == null) {
-                Log.e("XinmeiTuluUrlActivity", "Unable to parse URI from intent $intent")
+                Log.e("UrlActivity", "Unable to parse URI from intent $intent")
                 finish()
                 exitProcess(1)
             }
@@ -32,7 +32,7 @@ class XinmeituluUrlActivity : Activity() {
             try {
                 startActivity(mainIntent)
             } catch (e: ActivityNotFoundException) {
-                Log.e("XinmeiTuluUrlActivity", e.toString())
+                Log.e("UrlActivity", e.toString())
             }
         }
 

--- a/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/UrlActivity.kt
+++ b/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/UrlActivity.kt
@@ -11,39 +11,20 @@ class UrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val host = intent?.data?.host
-        val pathSegments = intent?.data?.pathSegments
 
-        if (host != null && pathSegments != null) {
-            val query = fromUrl(pathSegments)
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            if (query == null) {
-                Log.e("UrlActivity", "Unable to parse URI from intent $intent")
-                finish()
-                exitProcess(1)
-            }
-
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", query)
-                putExtra("filter", packageName)
-            }
-
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("UrlActivity", e.toString())
-            }
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("UrlActivity", "Unable to launch activity", e)
         }
 
         finish()
         exitProcess(0)
-    }
-
-    private fun fromUrl(pathSegments: MutableList<String>): String? = if (pathSegments.size >= 2) {
-        val slug = pathSegments[1]
-        "SLUG:$slug"
-    } else {
-        null
     }
 }

--- a/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/Xinmeitulu.kt
+++ b/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/Xinmeitulu.kt
@@ -44,8 +44,11 @@ class Xinmeitulu : HttpSource() {
                 setUrlWithoutDomain(element.select("figure > a").attr("abs:href"))
                 title = element.select("figcaption").text()
                 thumbnail_url = element.select("img").attr("abs:data-original-")
-                genre = element.select("a[rel='tag category']").last()?.text()
-                    ?.removeSuffix("写真")?.translate()
+                genre = element.select("a[rel='tag category']")
+                    .joinToString {
+                        it.text().removeSuffix("写真")
+                            .translate()
+                    }
             }
         }
         val hasNextPage = document.selectFirst(".next") != null

--- a/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/Xinmeitulu.kt
+++ b/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/Xinmeitulu.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.all.xinmeitulu
 
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
+import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -9,11 +10,15 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.firstInstanceOrNull
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
 import rx.Observable
+import java.util.Locale
 
 class Xinmeitulu : HttpSource() {
     override val baseUrl = "https://www.xinmeitulu.com"
@@ -39,7 +44,8 @@ class Xinmeitulu : HttpSource() {
                 setUrlWithoutDomain(element.select("figure > a").attr("abs:href"))
                 title = element.select("figcaption").text()
                 thumbnail_url = element.select("img").attr("abs:data-original-")
-                genre = element.select("a.tag").joinToString(", ") { it.text() }
+                genre = element.select("a[rel='tag category']").last()?.text()
+                    ?.removeSuffix("写真")?.translate()
             }
         }
         val hasNextPage = document.selectFirst(".next") != null
@@ -48,7 +54,22 @@ class Xinmeitulu : HttpSource() {
 
     // Search
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList) = GET("$baseUrl/page/$page?s=$query", headers)
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        val filterList = filters.ifEmpty { getFilterList() }
+        val regionFilter = filterList.firstInstanceOrNull<RegionFilter>()
+
+        val url = baseUrl.toHttpUrl().newBuilder().apply {
+            regionFilter?.toUriPart()?.let {
+                addPathSegment("area")
+                addPathSegment(it)
+            }
+            addPathSegment("page")
+            addPathSegment(page.toString())
+            addQueryParameter("s", query)
+        }.toString()
+
+        return GET(url, headers)
+    }
 
     override fun searchMangaParse(response: Response) = popularMangaParse(response)
 
@@ -66,9 +87,28 @@ class Xinmeitulu : HttpSource() {
         val document = response.asJsoup()
         setUrlWithoutDomain(document.selectFirst("link[rel=canonical]")!!.attr("abs:href"))
         title = document.select(".container > h1").text()
-        description = document.select(".container > *:not(div)").text()
         status = SManga.COMPLETED
         thumbnail_url = document.selectFirst("figure img")!!.attr("abs:data-original")
+        description = document.select(".container > p").joinToString("\n") {
+            val str = it.text()
+            if (str.contains("拍摄机构：")) {
+                author = str.replace("拍摄机构：", "").trim()
+            }
+            str.replace("拍摄机构：", "${"拍摄机构".translate()}: ")
+                .replace("相关编号：", "${"相关编号".translate()}: ")
+                .replace("图片数量：", "${"图片数量".translate()}: ")
+                .replace("发行日期：", "${"发行日期".translate()}: ")
+                .replace("出镜模特：", "${"出镜模特".translate()}: ")
+                .replace("别名：", "\n${"别名".translate()}: ")
+                .replace("生日：", "\n${"生日".translate()}: ")
+                .replace("身高：", "\n${"身高".translate()}: ")
+                .replace("三围：", "\n${"三围".translate()}: ")
+                .replace("罩杯：", "\n${"罩杯".translate()}: ")
+                .replace("杯", "-${"杯".translate()}")
+                .replace("匿名", "匿名".translate())
+                .replace("；", "")
+                .trim()
+        }
     }
 
     // Chapters
@@ -78,7 +118,7 @@ class Xinmeitulu : HttpSource() {
         return listOf(
             SChapter.create().apply {
                 setUrlWithoutDomain(document.selectFirst("link[rel=canonical]")!!.attr("abs:href"))
-                name = document.select(".container > h1").text()
+                name = "Gallery"
             },
         )
     }
@@ -92,6 +132,62 @@ class Xinmeitulu : HttpSource() {
         }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
+
+    // Filters
+
+    override fun getFilterList(): FilterList = FilterList(
+        RegionFilter(getRegionList()),
+    )
+
+    private class RegionFilter(vals: Array<Pair<String?, String>>) : UriPartFilter("Region", vals)
+
+    private fun getRegionList(): Array<Pair<String?, String>> = arrayOf(
+        null to "全部".translate(),
+        "zhongguodalumeinyu" to "中国大陆美女".translate(),
+        "taiguomeinyu" to "泰国美女".translate(),
+        "ribenmeinyu" to "日本美女".translate(),
+        "hanguomeinyu" to "韩国美女".translate(),
+        "taiwanmeinyu" to "台湾美女".translate(),
+        "oumeimeinyu" to "欧美美女".translate(),
+    )
+
+    private fun String.translate(): String {
+        if (Locale.getDefault().language.startsWith("zh")) return this
+        return when (this) {
+            // Region
+            "全部" -> "All"
+            "中国大陆美女" -> "Chinese beauty"
+            "泰国美女" -> "Thailand beauty"
+            "日本美女" -> "Japanese beauty"
+            "韩国美女" -> "Korean beauty"
+            "台湾美女" -> "Taiwanese beauty"
+            "欧美美女" -> "European & American beauty"
+            // Descriptions
+            "拍摄机构" -> "Studio"
+            "相关编号" -> "Issue number"
+            "图片数量" -> "Photos"
+            "发行日期" -> "Release date"
+            "出镜模特" -> "Model"
+            "别名" -> "Alias"
+            "生日" -> "Birthday"
+            "身高" -> "Height"
+            "三围" -> "Measurements"
+            "罩杯" -> "Cup size"
+            "杯" -> "cup"
+            "匿名" -> "Unknown"
+            else -> this
+        }
+    }
+
+    private open class UriPartFilter(
+        displayName: String,
+        val vals: Array<Pair<String?, String>>,
+    ) : Filter.Select<String>(
+        displayName,
+        vals.map { it.second }.toTypedArray(),
+    ) {
+        fun toUriPart() = vals[state].first
+    }
 
     companion object {
         private fun contentTypeIntercept(chain: Interceptor.Chain): Response {

--- a/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/Xinmeitulu.kt
+++ b/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/Xinmeitulu.kt
@@ -76,12 +76,24 @@ class Xinmeitulu : HttpSource() {
 
     override fun searchMangaParse(response: Response) = popularMangaParse(response)
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith("SLUG:")) {
-        val slug = query.removePrefix("SLUG:")
-        client.newCall(GET("$baseUrl/photo/$slug", headers)).asObservableSuccess()
-            .map { response -> MangasPage(listOf(mangaDetailsParse(response)), false) }
-    } else {
-        super.fetchSearchManga(page, query, filters)
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val slug = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return fetchSearchManga(page, "SLUG:$slug", filters)
+        }
+
+        return if (query.startsWith("SLUG:")) {
+            val slug = query.removePrefix("SLUG:")
+            client.newCall(GET("$baseUrl/photo/$slug", headers)).asObservableSuccess()
+                .map { response -> MangasPage(listOf(mangaDetailsParse(response)), false) }
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     // Details

--- a/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/Xinmeitulu.kt
+++ b/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/Xinmeitulu.kt
@@ -2,26 +2,20 @@ package eu.kanade.tachiyomi.extension.all.xinmeitulu
 
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
-import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
-import org.jsoup.nodes.Document
-import org.jsoup.nodes.Element
 import rx.Observable
-import java.util.Locale
 
-class Xinmeitulu : ParsedHttpSource() {
+class Xinmeitulu : HttpSource() {
     override val baseUrl = "https://www.xinmeitulu.com"
     override val lang = "all"
     override val name = "Xinmeitulu"
@@ -32,155 +26,72 @@ class Xinmeitulu : ParsedHttpSource() {
     // Latest
 
     override fun latestUpdatesRequest(page: Int) = throw UnsupportedOperationException()
-    override fun latestUpdatesNextPageSelector() = throw UnsupportedOperationException()
-    override fun latestUpdatesSelector() = throw UnsupportedOperationException()
-    override fun latestUpdatesFromElement(element: Element) = throw UnsupportedOperationException()
+    override fun latestUpdatesParse(response: Response): MangasPage = throw UnsupportedOperationException()
 
     // Popular
 
     override fun popularMangaRequest(page: Int) = GET("$baseUrl/page/$page")
-    override fun popularMangaNextPageSelector() = ".next"
-    override fun popularMangaSelector() = ".container > .row > div:has(figure)"
-    override fun popularMangaFromElement(element: Element) = SManga.create().apply {
-        setUrlWithoutDomain(element.select("figure > a").attr("abs:href"))
-        title = element.select("figcaption").text()
-        thumbnail_url = element.select("img").attr("abs:data-original-")
-        genre = element.select("a[rel='tag category']").last()?.text()
-            ?.removeSuffix("写真")?.let { translate(it) }
+
+    override fun popularMangaParse(response: Response): MangasPage {
+        val document = response.asJsoup()
+        val mangas = document.select(".container > .row > div:has(figure)").map { element ->
+            SManga.create().apply {
+                setUrlWithoutDomain(element.select("figure > a").attr("abs:href"))
+                title = element.select("figcaption").text()
+                thumbnail_url = element.select("img").attr("abs:data-original-")
+                genre = element.select("a.tag").joinToString(", ") { it.text() }
+            }
+        }
+        val hasNextPage = document.selectFirst(".next") != null
+        return MangasPage(mangas, hasNextPage)
     }
 
     // Search
 
-    override fun searchMangaFromElement(element: Element) = popularMangaFromElement(element)
-    override fun searchMangaNextPageSelector() = popularMangaNextPageSelector()
-    override fun searchMangaSelector() = popularMangaSelector()
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val filterList = filters.let { if (it.isEmpty()) getFilterList() else it }
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList) = GET("$baseUrl/page/$page?s=$query", headers)
 
-        val url = baseUrl.toHttpUrl().newBuilder()
-
-        if (!filterList.isEmpty()) {
-            filterList.forEach { filter ->
-                when (filter) {
-                    is RegionFilter -> filter.toUriPart()?.let {
-                        url
-                            .addPathSegment("area")
-                            .addPathSegment(it)
-                    }
-                    else -> {}
-                }
-            }
-        }
-
-        url.addPathSegment("page").addPathSegment(page.toString())
-        url.addQueryParameter("s", query)
-
-        return GET(url.toString(), headers)
-    }
+    override fun searchMangaParse(response: Response) = popularMangaParse(response)
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith("SLUG:")) {
         val slug = query.removePrefix("SLUG:")
         client.newCall(GET("$baseUrl/photo/$slug", headers)).asObservableSuccess()
-            .map { response -> MangasPage(listOf(mangaDetailsParse(response.asJsoup())), false) }
+            .map { response -> MangasPage(listOf(mangaDetailsParse(response)), false) }
     } else {
         super.fetchSearchManga(page, query, filters)
     }
 
     // Details
 
-    override fun mangaDetailsParse(document: Document) = SManga.create().apply {
+    override fun mangaDetailsParse(response: Response) = SManga.create().apply {
+        val document = response.asJsoup()
         setUrlWithoutDomain(document.selectFirst("link[rel=canonical]")!!.attr("abs:href"))
         title = document.select(".container > h1").text()
+        description = document.select(".container > *:not(div)").text()
         status = SManga.COMPLETED
         thumbnail_url = document.selectFirst("figure img")!!.attr("abs:data-original")
-        description = document.select(".container > p").joinToString("\n") {
-            val str = it.text()
-            if (str.contains("拍摄机构：")) {
-                author = str.replace("拍摄机构：", "").trim()
-            }
-            str.replace("拍摄机构：", "${translate("拍摄机构")}: ")
-                .replace("相关编号：", "${translate("相关编号")}: ")
-                .replace("图片数量：", "${translate("图片数量")}: ")
-                .replace("发行日期：", "${translate("发行日期")}: ")
-                .replace("出镜模特：", "${translate("出镜模特")}: ")
-                .replace("别名：", "\n${translate("别名")}: ")
-                .replace("生日：", "\n${translate("生日")}: ")
-                .replace("身高：", "\n${translate("身高")}: ")
-                .replace("三围：", "\n${translate("三围")}: ")
-                .replace("罩杯：", "\n${translate("罩杯")}: ")
-                .replace("杯", "-${translate("杯")}")
-                .replace("匿名", translate("匿名"))
-                .replace("；", "")
-                .trim()
-        }
     }
 
     // Chapters
 
-    override fun chapterListSelector() = "html"
-
-    override fun chapterFromElement(element: Element) = SChapter.create().apply {
-        setUrlWithoutDomain(element.selectFirst("link[rel=canonical]")!!.attr("abs:href"))
-        name = "Gallery" // Recheck how it affect download
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val document = response.asJsoup()
+        return listOf(
+            SChapter.create().apply {
+                setUrlWithoutDomain(document.selectFirst("link[rel=canonical]")!!.attr("abs:href"))
+                name = document.select(".container > h1").text()
+            },
+        )
     }
 
-    override fun pageListParse(document: Document) = document.select(".container > div > figure img").mapIndexed { index, element ->
-        Page(index, imageUrl = element.attr("abs:data-original"))
-    }
+    // Pages
 
-    override fun imageUrlParse(document: Document): String = throw UnsupportedOperationException()
-
-    // Filters
-
-    override fun getFilterList(): FilterList = FilterList(
-        RegionFilter(getRegionList()),
-    )
-
-    private class RegionFilter(vals: Array<Pair<String?, String>>) : UriPartFilter("Region", vals)
-
-    private fun getRegionList(): Array<Pair<String?, String>> = arrayOf(
-        null to translate("全部"),
-        "zhongguodalumeinyu" to translate("中国大陆美女"),
-        "taiguomeinyu" to translate("泰国美女"),
-        "ribenmeinyu" to translate("日本美女"),
-        "hanguomeinyu" to translate("韩国美女"),
-        "taiwanmeinyu" to translate("台湾美女"),
-        "oumeimeinyu" to translate("欧美美女"),
-    )
-
-    private fun translate(it: String): String {
-        if (Locale.getDefault().language == "zh") return it
-        return when (it) {
-            // Region
-            "全部" -> "All"
-            "中国大陆美女" -> "Chinese beauty"
-            "泰国美女" -> "Thailand beauty"
-            "日本美女" -> "Japanese beauty"
-            "韩国美女" -> "Korean beauty"
-            "台湾美女" -> "Taiwanese beauty"
-            "欧美美女" -> "European & American beauty"
-            // Descriptions
-            "拍摄机构" -> "Studio"
-            "相关编号" -> "Issue number"
-            "图片数量" -> "Photos"
-            "发行日期" -> "Release date"
-            "出镜模特" -> "Model"
-            "别名" -> "Alias"
-            "生日" -> "Birthday"
-            "身高" -> "Height"
-            "三围" -> "Measurements"
-            "罩杯" -> "Cup size"
-            "杯" -> "cup"
-            "匿名" -> "Unknown"
-            else -> {
-                it
-            }
+    override fun pageListParse(response: Response) = response.asJsoup()
+        .select(".container > div > figure img")
+        .mapIndexed { index, element ->
+            Page(index, imageUrl = element.attr("abs:data-original"))
         }
-    }
 
-    private open class UriPartFilter(displayName: String, val vals: Array<Pair<String?, String>>) : Filter.Select<String>(displayName, vals.map { it.second }.toTypedArray()) {
-        fun toUriPart() = vals[state].first
-    }
+    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 
     companion object {
         private fun contentTypeIntercept(chain: Interceptor.Chain): Response {


### PR DESCRIPTION
## Summary by Sourcery

Migrate the Xinmeitulu extension from ParsedHttpSource to HttpSource and add support for opening site URLs directly into Tachiyomi search.

New Features:
- Allow users to share or open Xinmeitulu URLs into Tachiyomi via a dedicated URL handler activity.

Enhancements:
- Refactor popular, search, details, chapter, and page parsing to use Response-based HttpSource methods instead of ParsedHttpSource selectors.
- Update search logic to support URL-based queries and improve region filter handling and translation utilities.
- Adjust translation helper to use an extension function and broaden Chinese locale detection.

Build:
- Update Xinmeitulu extension metadata, including version codes, in build.gradle.