### PR TITLE
Migrate back to Keiyoushi's ext-lib

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.re
 okhttp = { module = "com.squareup.okhttp3:okhttp", version = "5.3.2" }
 quickjs = { module = "app.cash.quickjs:quickjs-android", version = "0.9.2" }
 rxjava = { module = "io.reactivex:rxjava", version = "1.3.8" }
-tachiyomi-lib = { module = "com.github.komikku-app:extensions-lib", version = "b6fb731bf6" }
+tachiyomi-lib = { module = "com.github.keiyoushi:extensions-lib", version = "18a8e26be2" }
 
 # Required by Kotlin 2.x compiler to resolve type-use annotations (e.g. org.jspecify.annotations.Nullable) used in Jsoup's API signatures
 jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -124,7 +124,7 @@ abstract class Hentai3 :
             ?: emptyList()
 
     override val client: OkHttpClient by lazy {
-        network.cloudflareClient.newBuilder()
+        network.client.newBuilder()
             .addNetworkInterceptor(::authorizationInterceptor)
             .build()
     }

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -12,7 +12,7 @@ import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getTagDescription
 import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getTags
 import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getTime
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
@@ -32,6 +32,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Element
+import rx.Observable
 import java.io.IOException
 
 @Source
@@ -207,29 +208,29 @@ abstract class Hentai3 :
 
     // Search
 
-    override suspend fun getSearchManga(page: Int, query: String, filters: FilterList): MangasPage {
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
         if (query.startsWith("https://")) {
             val url = query.toHttpUrl()
             if (url.host != baseUrl.toHttpUrl().host || url.pathSegments.size < 2) {
                 throw Exception("Unsupported url")
             }
             val id = url.pathSegments[1]
-            return getSearchManga(page, "$PREFIX_ID_SEARCH$id", filters)
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$id", filters)
         }
 
         return when {
             query.startsWith(PREFIX_ID_SEARCH) -> {
                 val id = query.removePrefix(PREFIX_ID_SEARCH)
                 client.newCall(searchMangaByIdRequest(id))
-                    .awaitSuccess()
-                    .use { response -> searchMangaByIdParse(response, id) }
+                    .asObservableSuccess()
+                    .map { response -> searchMangaByIdParse(response, id) }
             }
             query.toIntOrNull() != null -> {
                 client.newCall(searchMangaByIdRequest(query))
-                    .awaitSuccess()
-                    .use { response -> searchMangaByIdParse(response, query) }
+                    .asObservableSuccess()
+                    .map { response -> searchMangaByIdParse(response, query) }
             }
-            else -> super.getSearchManga(page, query, filters)
+            else -> super.fetchSearchManga(page, query, filters)
         }
     }
 

--- a/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
+++ b/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
@@ -289,7 +289,7 @@ abstract class MissKon :
         tagsFetching = true
         tagsFetchAttempt++
         launchIO {
-            runCatching {
+            try {
                 client.newCall(GET("$baseUrl/sets/", headers)).execute()
                     .use { it.asJsoup() }
                     .select(".entry .tag-counterz a[href*=/tag/]")
@@ -306,7 +306,8 @@ abstract class MissKon :
                         updateTags(newTags.toSet(), true)
                         tagsFetched = true
                     }
-            }.onFailure {
+            } catch (_: Exception) {
+            } finally {
                 tagsFetching = false
             }
         }

--- a/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
+++ b/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
@@ -209,16 +210,14 @@ abstract class MissKon :
     // endregion
 
     // region Pages
-    override suspend fun getPageList(chapter: SChapter): List<Page> {
-        val response = client.newCall(pageListRequest(chapter)).await()
-        return response.use { resp ->
+    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = client.newCall(pageListRequest(chapter)).asObservableSuccess()
+        .map { resp ->
             if (preferences.splitPages) {
                 pageListParse(resp)
             } else {
                 pageListMerge(resp)
             }
         }
-    }
 
     private val imageListSelector = "div.post-inner > div.entry > p > img"
 
@@ -226,7 +225,7 @@ abstract class MissKon :
         .select(imageListSelector)
         .mapIndexed { i, img -> Page(i, imageUrl = img.imgAttr()) }
 
-    private suspend fun pageListMerge(response: Response): List<Page> {
+    private fun pageListMerge(response: Response): List<Page> {
         val document = response.asJsoup()
         val pages = document
             .select("div.page-link:first-of-type a")
@@ -236,13 +235,15 @@ abstract class MissKon :
 
         val chapterPage = parseImageList(document).toMutableList()
 
-        coroutineScope {
-            chapterPage += pages.map { url ->
-                async(Dispatchers.IO) {
-                    val request = GET(url, headers)
-                    parseImageList(client.newCall(request).await().use { it.asJsoup() })
-                }
-            }.awaitAll().flatten()
+        runBlocking(Dispatchers.IO) {
+            coroutineScope {
+                chapterPage += pages.map { url ->
+                    async(Dispatchers.IO) {
+                        val request = GET(url, headers)
+                        parseImageList(client.newCall(request).await().use { it.asJsoup() })
+                    }
+                }.awaitAll().flatten()
+            }
         }
 
         return chapterPage.mapIndexed { index, url ->

--- a/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
+++ b/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
@@ -6,6 +6,7 @@ import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Filter
@@ -33,6 +34,7 @@ import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
 import kotlin.time.Duration.Companion.seconds
@@ -108,9 +110,11 @@ abstract class MissKon :
                 }
                 url.addQueryParameter("s", query.trim())
             }
+
             topDaysFilter != null && topDaysFilter.state > 0 -> {
                 url.addPathSegment(topDaysFilter.toUriPart())
             }
+
             tagFilter != null && tagFilter.state > 0 -> {
                 url.addPathSegment("tag")
                 url.addPathSegment(tagFilter.toUriPart())
@@ -118,6 +122,7 @@ abstract class MissKon :
                 url.addPathSegment("page")
                 url.addPathSegment(page.toString())
             }
+
             else -> return latestUpdatesRequest(page)
         }
         return GET(url.build(), headers)
@@ -142,9 +147,11 @@ abstract class MissKon :
                 "[$serviceText]($link)"
             }
 
-            description = "${info.html()
-                .replace("<input.*?>".toRegex(), password)
-                .replace("<.+?>".toRegex(), "")}\n\n" +
+            description = "${
+                info.html()
+                    .replace("<input.*?>".toRegex(), password)
+                    .replace("<.+?>".toRegex(), "")
+            }\n\n" +
                 "$view\n\n" +
                 downloadLinks
             genre = document.parseTags()
@@ -153,36 +160,38 @@ abstract class MissKon :
         }
     }
 
-    override suspend fun getChapterList(manga: SManga): List<SChapter> {
-        val doc = client.newCall(chapterListRequest(manga)).await().use { it.asJsoup() }
-        val dateUploadStr = doc.selectFirst(".entry img")?.imgAttr()
-            ?.let { url ->
-                FULL_DATE_REGEX.find(url)?.groupValues?.get(1)
-                    ?: YEAR_MONTH_REGEX.find(url)?.groupValues?.get(1)?.let { "$it/01" }
-            }
-
-        val dateUpload = FULL_DATE_FORMAT.tryParse(dateUploadStr)
-        if (preferences.splitPages) {
-            val maxPage = doc.select("div.page-link:first-of-type a.post-page-numbers").last()?.text()?.toIntOrNull() ?: 1
-            return (maxPage downTo 1).map { page ->
-                SChapter.create().apply {
-                    setUrlWithoutDomain("${manga.url}/$page")
-                    name = "Page $page"
-                    chapter_number = page.toFloat()
-                    date_upload = dateUpload
+    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = client.newCall(chapterListRequest(manga))
+        .asObservableSuccess()
+        .map { response ->
+            val doc = response.asJsoup()
+            val dateUploadStr = doc.selectFirst(".entry img")?.imgAttr()
+                ?.let { url ->
+                    FULL_DATE_REGEX.find(url)?.groupValues?.get(1)
+                        ?: YEAR_MONTH_REGEX.find(url)?.groupValues?.get(1)?.let { "$it/01" }
                 }
+
+            val dateUpload = FULL_DATE_FORMAT.tryParse(dateUploadStr)
+            if (preferences.splitPages) {
+                val maxPage = doc.select("div.page-link:first-of-type a.post-page-numbers").last()?.text()?.toIntOrNull() ?: 1
+                (maxPage downTo 1).map { page ->
+                    SChapter.create().apply {
+                        setUrlWithoutDomain("${manga.url}/$page")
+                        name = "Page $page"
+                        chapter_number = page.toFloat()
+                        date_upload = dateUpload
+                    }
+                }
+            } else {
+                listOf(
+                    SChapter.create().apply {
+                        chapter_number = 0F
+                        setUrlWithoutDomain(manga.url)
+                        name = "Gallery"
+                        date_upload = dateUpload
+                    },
+                )
             }
-        } else {
-            return listOf(
-                SChapter.create().apply {
-                    chapter_number = 0F
-                    setUrlWithoutDomain(manga.url)
-                    name = "Gallery"
-                    date_upload = dateUpload
-                },
-            )
         }
-    }
 
     override fun chapterListParse(response: Response): List<SChapter> = throw UnsupportedOperationException()
 

--- a/src/all/photos18/src/eu/kanade/tachiyomi/extension/all/photos18/Photos18.kt
+++ b/src/all/photos18/src/eu/kanade/tachiyomi/extension/all/photos18/Photos18.kt
@@ -22,6 +22,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
+import rx.Observable
 import java.net.URLDecoder
 
 @Source
@@ -105,13 +106,13 @@ abstract class Photos18 :
         }
     }
 
-    override suspend fun getChapterList(manga: SManga): List<SChapter> {
+    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
         val chapter = SChapter.create().apply {
             url = manga.url
             name = "Gallery"
             chapter_number = 0f
         }
-        return listOf(chapter)
+        return Observable.just(listOf(chapter))
     }
 
     override fun chapterListParse(response: Response) = throw UnsupportedOperationException()

--- a/src/en/hiperdex/build.gradle.kts
+++ b/src/en/hiperdex/build.gradle.kts
@@ -4,11 +4,11 @@ plugins {
 
 keiyoushi {
     name = "Hiperdex"
-    versionCode = 29
+    versionCode = 30
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
     theme = "madara"
-    kmkVersionCode = 2
+    kmkVersionCode = 1
 
     source {
         lang = "en"

--- a/src/en/mangadistrict/build.gradle.kts
+++ b/src/en/mangadistrict/build.gradle.kts
@@ -4,11 +4,11 @@ plugins {
 
 keiyoushi {
     name = "Manga District"
-    versionCode = 16
+    versionCode = 17
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
     theme = "madara"
-    kmkVersionCode = 2
+    kmkVersionCode = 1
 
     source {
         lang = "en"


### PR DESCRIPTION
## Summary by Sourcery

Migrate extensions to use Keiyoushi’s extensions-lib and align chapter list handling with observable-based APIs.

Enhancements:
- Update MissKon and Photos18 chapter list implementations to use reactive fetchChapterList with RxJava observables instead of suspend getChapterList.

Build:
- Switch tachiyomi-lib dependency from komikku-app:extensions-lib to keiyoushi:extensions-lib with the new revision.