### PR TITLE
Hiper: Fix page loading

### DIFF
--- a/lib-multisrc/hiper/build.gradle.kts
+++ b/lib-multisrc/hiper/build.gradle.kts
@@ -7,6 +7,6 @@ dependencies {
 }
 
 keiyoushi {
-    baseVersionCode = 2
+    baseVersionCode = 3
     libVersion = "1.4"
 }

--- a/lib-multisrc/hiper/build.gradle.kts
+++ b/lib-multisrc/hiper/build.gradle.kts
@@ -7,6 +7,6 @@ dependencies {
 }
 
 keiyoushi {
-    baseVersionCode = 1
+    baseVersionCode = 2
     libVersion = "1.4"
 }

--- a/lib-multisrc/hiper/build.gradle.kts
+++ b/lib-multisrc/hiper/build.gradle.kts
@@ -7,6 +7,6 @@ dependencies {
 }
 
 keiyoushi {
-    baseVersionCode = 3
+    baseVersionCode = 4
     libVersion = "1.4"
 }

--- a/lib-multisrc/hiper/src/eu/kanade/tachiyomi/multisrc/hiper/Hiper.kt
+++ b/lib-multisrc/hiper/src/eu/kanade/tachiyomi/multisrc/hiper/Hiper.kt
@@ -52,7 +52,6 @@ abstract class Hiper :
 
     override fun headersBuilder(): Headers.Builder = super.headersBuilder()
         .set("Referer", "$baseUrl/")
-        .add("X-Hpx-Nexus", "hpx-block-f91")
 
     private val acceptHeaders = headersBuilder()
         .set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")

--- a/lib-multisrc/hiper/src/eu/kanade/tachiyomi/multisrc/hiper/Hiper.kt
+++ b/lib-multisrc/hiper/src/eu/kanade/tachiyomi/multisrc/hiper/Hiper.kt
@@ -172,11 +172,7 @@ abstract class Hiper :
     override fun getMangaUrl(manga: SManga): String = "$baseUrl${manga.url}"
 
     override fun mangaDetailsRequest(manga: SManga): Request {
-        val slug = manga.url
-            .substringAfterLast("$mangaPath/")
-            .substringBefore("#")
-            .takeIf(String::isNotBlank)
-            ?: throw IOException("Migrate from $name to $name")
+        val slug = manga.url.getSlug()
 
         val input = buildJsonObject {
             putJsonObject("0") {
@@ -208,7 +204,10 @@ abstract class Hiper :
 
     // ============================ Chapters ==================================
 
-    override fun getChapterUrl(chapter: SChapter) = baseUrl + chapter.url.substringBefore('#') + "/" + chapter.url.substringAfterLast('/')
+    override fun getChapterUrl(chapter: SChapter): String {
+        val slug = chapter.url.getSlug()
+        return "$baseUrl/$mangaPath/$slug/${chapter.getNumber()}".removeSuffix(".0")
+    }
 
     override fun chapterListRequest(manga: SManga): Request {
         val mangaId = manga.url.substringAfterLast("#").toLongOrNull()
@@ -262,11 +261,7 @@ abstract class Hiper :
     // ============================ Pages =====================================
 
     override fun pageListRequest(chapter: SChapter): Request {
-        val slug = chapter.url
-            .substringAfterLast("$mangaPath/")
-            .substringBefore("#")
-            .takeIf(String::isNotBlank)
-            ?: throw IOException("Migrate from $name to $name")
+        val slug = chapter.url.getSlug()
 
         val input = buildJsonObject {
             putJsonObject("0") {
@@ -285,7 +280,7 @@ abstract class Hiper :
             putJsonObject("2") {
                 putJsonObject("json") {
                     put("seriesSlug", slug)
-                    put("chapterNumber", chapter.chapter_number)
+                    put("chapterNumber", chapter.getNumber())
                 }
             }
             putJsonObject("3") {
@@ -358,11 +353,9 @@ abstract class Hiper :
                     if (url.startsWith("$baseUrl/api")) {
                         val allHeaders = request.requestHeaders
                         if (allHeaders.isNotEmpty()) {
-                            wvHeaders = Headers.Builder().apply {
+                            wvHeaders = headers.newBuilder().apply {
                                 allHeaders.forEach { (key, value) ->
-                                    if (headers.get(key) == null) {
-                                        add(key, value)
-                                    }
+                                    headers.get(key) ?: add(key, value)
                                 }
                             }.build()
                         }
@@ -484,5 +477,21 @@ abstract class Hiper :
         private const val MAX_RATING_DEFAULT = "pornographic"
         private val MAX_RATING_ENTRIES = arrayOf("Pornographic", "Erotica", "Suggestive", "Safe")
         private val MAX_RATING_VALUES = arrayOf("pornographic", "erotica", "suggestive", "safe")
+    }
+
+    // Old (New)
+    // manga: /manga/<slug|(#ID)>
+    // chapter: /manga/slug(#ID)/<chapter-XX|(XX.X)>
+
+    fun String.getSlug() = this.substringAfterLast("$mangaPath/")
+        .substringBefore("/")
+        .substringBefore("#")
+        .takeIf(String::isNotBlank)
+        ?: throw IOException("Migrate from $name to $name")
+
+    fun SChapter.getNumber() = if (chapter_number > 0) {
+        chapter_number
+    } else {
+        url.trim('/').substringAfterLast("/").substringAfter("-").toFloatOrNull() ?: 1f
     }
 }

--- a/lib-multisrc/hiper/src/eu/kanade/tachiyomi/multisrc/hiper/Hiper.kt
+++ b/lib-multisrc/hiper/src/eu/kanade/tachiyomi/multisrc/hiper/Hiper.kt
@@ -1,5 +1,11 @@
 package eu.kanade.tachiyomi.multisrc.hiper
 
+import android.os.Handler
+import android.os.Looper
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.GET
@@ -11,7 +17,9 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.lib.i18n.Intl
+import keiyoushi.utils.applicationContext
 import keiyoushi.utils.get
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
@@ -19,6 +27,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
@@ -26,7 +35,10 @@ import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
+import rx.Observable
 import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 abstract class Hiper :
     HttpSource(),
@@ -46,9 +58,22 @@ abstract class Hiper :
         .set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
         .build()
 
+    private val handler by lazy { Handler(Looper.getMainLooper()) }
+
+    private var wvHeaders: Headers? = null
+
     override val client = network.client.newBuilder()
         .addInterceptor { chain ->
-            val response = chain.proceed(chain.request())
+            var request = chain.request()
+
+            wvHeaders?.let {
+                request = request.newBuilder()
+                    .headers(it)
+                    .build()
+            }
+
+            val response = chain.proceed(request)
+
             // Fetch baseUrl with accept headers which then populates a cookie
             if (response.code == 401) {
                 response.close()
@@ -184,6 +209,8 @@ abstract class Hiper :
 
     // ============================ Chapters ==================================
 
+    override fun getChapterUrl(chapter: SChapter) = baseUrl + chapter.url.substringBefore('#') + "/" + chapter.url.substringAfterLast('/')
+
     override fun chapterListRequest(manga: SManga): Request {
         val mangaId = manga.url.substringAfterLast("#").toLongOrNull()
             ?: throw IOException("Migrate from $name to $name")
@@ -277,11 +304,83 @@ abstract class Hiper :
         return GET(url, headers)
     }
 
-    override fun pageListParse(response: Response): List<Page> {
-        val element = response.parseAs<List<JsonElement>>().last()
-        val pages = element["result"]["data"]["json"]?.parseAs<List<PageDto>>() ?: return emptyList()
+    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = Observable.fromCallable {
+        val chapterUrl = getChapterUrl(chapter)
+
+        val request = pageListRequest(chapter)
+        val response = client.newCall(request).execute()
+        val resJson = parsePages(response)
+
+        resJson?.takeIf { it.isNotEmpty() } ?: run {
+            fetchHeadersWv(chapterUrl)
+
+            wvHeaders?.let {
+                val response = client.newCall(request).execute()
+                parsePages(response) ?: emptyList()
+            } ?: error("Failed to get headers")
+        }
+    }
+
+    private fun parsePages(response: Response): List<Page>? {
+        val elements = response.parseAs<List<JsonElement>>()
+
+        for (element in elements) {
+            if ("error" in element.jsonObject) {
+                return null
+            }
+        }
+
+        val lastElement = elements.last()
+        val pages = lastElement["result"]["data"]["json"]?.parseAs<List<PageDto>>() ?: return emptyList()
         return pages.map(PageDto::toPage)
     }
+
+    @Synchronized
+    fun fetchHeadersWv(url: String) {
+        val latch = CountDownLatch(1)
+        var webView: WebView? = null
+        val doc = client.newCall(GET(url, headers)).execute().asJsoup()
+
+        handler.post {
+            val wv = WebView(applicationContext).also { webView = it }
+
+            wv.settings.javaScriptEnabled = true
+            wv.settings.domStorageEnabled = true
+            wv.settings.loadsImagesAutomatically = false
+            wv.settings.blockNetworkImage = true
+            wv.settings.userAgentString = headers["user-agent"]
+
+            wv.webViewClient = object : WebViewClient() {
+                override fun shouldInterceptRequest(
+                    view: WebView,
+                    request: WebResourceRequest,
+                ): WebResourceResponse? {
+                    val url = request.url.toString()
+                    if (url.startsWith("$baseUrl/api")) {
+                        val allHeaders = request.requestHeaders
+                        if (allHeaders.isNotEmpty()) {
+                            wvHeaders = Headers.Builder().apply {
+                                allHeaders.forEach { (key, value) ->
+                                    if (headers.get(key) != null) {
+                                        add(key, value)
+                                    }
+                                }
+                            }.build()
+                        }
+                        latch.countDown()
+                        return null
+                    }
+                    return super.shouldInterceptRequest(view, request)
+                }
+            }
+            wv.loadDataWithBaseURL(doc.location(), doc.outerHtml(), "text/html", "utf-8", null)
+        }
+
+        latch.await(15, TimeUnit.SECONDS)
+        handler.post { webView?.destroy() }
+    }
+
+    override fun pageListParse(response: Response): List<Page> = throw UnsupportedOperationException()
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 

--- a/lib-multisrc/hiper/src/eu/kanade/tachiyomi/multisrc/hiper/Hiper.kt
+++ b/lib-multisrc/hiper/src/eu/kanade/tachiyomi/multisrc/hiper/Hiper.kt
@@ -361,7 +361,7 @@ abstract class Hiper :
                         if (allHeaders.isNotEmpty()) {
                             wvHeaders = Headers.Builder().apply {
                                 allHeaders.forEach { (key, value) ->
-                                    if (headers.get(key) != null) {
+                                    if (headers.get(key) == null) {
                                         add(key, value)
                                     }
                                 }

--- a/src/en/hiperdex/build.gradle.kts
+++ b/src/en/hiperdex/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Hiperdex"
-    versionCode = 82
+    versionCode = 81
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "hiper"

--- a/src/en/hiperdex/build.gradle.kts
+++ b/src/en/hiperdex/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Hiperdex"
-    versionCode = 81
+    versionCode = 80
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "hiper"

--- a/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
+++ b/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
@@ -17,6 +17,10 @@ import kotlin.time.Duration.Companion.minutes
 
 @Source
 abstract class Hiperdex : Hiper() {
+
+    override fun headersBuilder() = super.headersBuilder()
+        .set("x-hpx-nexus", "hpx-block-f91")
+
     override val client = super.client.newBuilder()
         .rateLimit(999999, 1.minutes)
         .build()

--- a/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
+++ b/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
@@ -19,7 +19,7 @@ import kotlin.time.Duration.Companion.minutes
 abstract class Hiperdex : Hiper() {
 
     override fun headersBuilder() = super.headersBuilder()
-        .set("x-svc-gate", "f5pabmx7sdek")
+        .set("x-cfg-auth", "yceqt7qgu004")
 
     override val client = super.client.newBuilder()
         .rateLimit(999999, 1.minutes)

--- a/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
+++ b/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
@@ -19,7 +19,7 @@ import kotlin.time.Duration.Companion.minutes
 abstract class Hiperdex : Hiper() {
 
     override fun headersBuilder() = super.headersBuilder()
-        .set("x-hpx-nexus", "hpx-block-f91")
+        .set("x-svc-gate", "f5pabmx7sdek")
 
     override val client = super.client.newBuilder()
         .rateLimit(999999, 1.minutes)

--- a/src/pt/hipercool/build.gradle.kts
+++ b/src/pt/hipercool/build.gradle.kts
@@ -14,7 +14,9 @@ keiyoushi {
     source {
         name = "Hipercool"
         lang = "pt-BR"
-        baseUrl = "https://lerhentais.com"
+        baseUrl {
+            custom("https://lerhentais.com")
+        }
         id = 2379514871370953957
     }
 }

--- a/src/pt/hipercool/src/eu/kanade/tachiyomi/extension/pt/hipercool/Hipercool.kt
+++ b/src/pt/hipercool/src/eu/kanade/tachiyomi/extension/pt/hipercool/Hipercool.kt
@@ -8,7 +8,7 @@ import keiyoushi.network.rateLimit
 abstract class Hipercool : Hiper() {
 
     override fun headersBuilder() = super.headersBuilder()
-        .set("x-lh-nexus", "c37-block-q24")
+        .set("x-flux-node", "G2ZsDdWhUwdU82Vw")
 
     override val client = super.client.newBuilder()
         .rateLimit(3)

--- a/src/pt/hipercool/src/eu/kanade/tachiyomi/extension/pt/hipercool/Hipercool.kt
+++ b/src/pt/hipercool/src/eu/kanade/tachiyomi/extension/pt/hipercool/Hipercool.kt
@@ -6,6 +6,10 @@ import keiyoushi.network.rateLimit
 
 @Source
 abstract class Hipercool : Hiper() {
+
+    override fun headersBuilder() = super.headersBuilder()
+        .set("x-lh-nexus", "c37-block-q24")
+
     override val client = super.client.newBuilder()
         .rateLimit(3)
         .build()


### PR DESCRIPTION
## Summary by Sourcery

Update Hiper-based sources to use slug helpers and WebView-acquired headers for page loading.

New Features:
- Add WebView-based fallback to capture authenticated headers when API page list requests fail.
- Introduce shared helpers to extract slugs and chapter numbers from URLs and reuse them across requests.
- Override source-specific headers for Hiperdex and Hipercool to satisfy new backend requirements.

Bug Fixes:
- Fix chapter URL and page list requests by correctly deriving slugs and chapter numbers from stored URLs.
- Handle API error responses during page list parsing and retry with refreshed headers from the WebView.

Enhancements:
- Refactor page list fetching to use Observable-based flow and centralized JSON page parsing.
- Adjust Hipercool base URL configuration to use the custom URL DSL.
- Increase Hiper multisrc base version code and adjust Hiperdex extension version code for compatibility.