### PR TITLE
Migrate to 1.6X

### DIFF
--- a/src/all/misskon/build.gradle.kts
+++ b/src/all/misskon/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 
 keiyoushi {
     name = "MissKon"
-    versionCode = 4
+    versionCode = 5
     contentWarning = ContentWarning.NSFW
-    libVersion = "1.4"
+    libVersion = "1.6"
     kmkVersionCode = 10
 
     source {

--- a/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
+++ b/src/all/misskon/src/eu/kanade/tachiyomi/extension/all/misskon/MissKon.kt
@@ -5,9 +5,6 @@ import android.net.Uri
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
-import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.asObservableSuccess
-import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -15,42 +12,38 @@ import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
-import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
 import keiyoushi.network.rateLimit
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.toJsonElement
 import keiyoushi.utils.tryParse
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonElement
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Request
+import okhttp3.OkHttpClient
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
 import kotlin.time.Duration.Companion.seconds
 
 @Source
 abstract class MissKon :
-    HttpSource(),
+    KeiSource(),
     ConfigurableSource {
     private val baseUrlHost by lazy { baseUrl.toHttpUrl().host }
 
-    override val supportsLatest = true
-
-    override val client = network.client.newBuilder()
-        .rateLimit(10, 1.seconds) { it.host == baseUrlHost }
-        .build()
+    override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = rateLimit(10, 1.seconds) { it.host == baseUrlHost }
 
     private val preferences by getPreferencesLazy()
 
@@ -68,7 +61,7 @@ abstract class MissKon :
     }
 
     // region popular
-    override fun popularMangaRequest(page: Int): Request {
+    override suspend fun getPopularManga(page: Int): MangasPage {
         val topDays = (preferences.topDays?.toInt() ?: 0) + 1
         val topDaysFilter = TopDaysFilter(
             "",
@@ -77,33 +70,23 @@ abstract class MissKon :
                 getTopDaysList()[topDays],
             ),
         ).apply { state = 1 }
-        return searchMangaRequest(page, "", FilterList(topDaysFilter))
-    }
-
-    override fun popularMangaParse(response: Response): MangasPage {
-        getTags()
-        val document = response.asJsoup()
-        val mangas = document.select("article.item-list").map { mangaFromElement(it) }
-        val hasNextPage = document.selectFirst(".current + a.page") != null
-        return MangasPage(mangas, hasNextPage)
+        return getSearchMangaList(page, "", FilterList(topDaysFilter))
     }
     // endregion
 
     // region latest
-    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/page/$page", headers)
-
-    override fun latestUpdatesParse(response: Response) = popularMangaParse(response)
+    override suspend fun getLatestUpdates(page: Int): MangasPage = parseMangaListPage(client.get("$baseUrl/page/$page"))
     // endregion
 
     // region Search
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         val tagFilter = filters.firstInstanceOrNull<TagsFilter>()
         val topDaysFilter = filters.firstInstanceOrNull<TopDaysFilter>()
         val url = baseUrl.toHttpUrl().newBuilder()
         when {
             query.isNotBlank() -> {
                 if (listOf("photo", "photos", "video", "videos").contains(query.trim())) {
-                    return GET("$baseUrl/search")
+                    return parseMangaListPage(client.get("$baseUrl/search"))
                 }
                 if (page > 1) {
                     url.addPathSegment("page")
@@ -124,81 +107,93 @@ abstract class MissKon :
                 url.addPathSegment(page.toString())
             }
 
-            else -> return latestUpdatesRequest(page)
+            else -> return getLatestUpdates(page)
         }
-        return GET(url.build(), headers)
+        return parseMangaListPage(client.get(url.build()))
     }
 
-    override fun searchMangaParse(response: Response) = popularMangaParse(response)
+    private fun parseMangaListPage(response: Response): MangasPage {
+        val document = response.asJsoup()
+        val mangas = document.select("article.item-list").map { mangaFromElement(it) }
+        val hasNextPage = document.selectFirst(".current + a.page") != null
+        return MangasPage(mangas, hasNextPage)
+    }
     // endregion
 
     // region Details
-    override fun mangaDetailsParse(response: Response): SManga {
-        val document = response.asJsoup()
-        return SManga.create().apply {
-            title = document.select(".post-title span").text()
-            val view = document.select("p.post-meta span.post-views").text()
-            val info = document.select("div.info div.box-inner-block")
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val document = client.get(getMangaUrl(manga)).asJsoup()
+        val updatedManga = parseMangaDetails(document)
+        val updatedChapters = parseChapterList(document, manga.url)
+        return SMangaUpdate(updatedManga, updatedChapters)
+    }
 
-            val password = info.select("input").attr("value")
-            val downloadAvailable = document.select("div.post-inner > div.entry > p > a[href]:has(i.fa-download)")
-            val downloadLinks = downloadAvailable.joinToString("\n") { element ->
-                val serviceText = element.text()
-                val link = element.attr("href")
-                "[$serviceText]($link)"
+    private fun parseMangaDetails(document: Document): SManga = SManga.create().apply {
+        title = document.select(".post-title span").text()
+        val view = document.select("p.post-meta span.post-views").text()
+        val info = document.select("div.info div.box-inner-block")
+
+        val password = info.select("input").attr("value")
+        val downloadAvailable = document.select("div.post-inner > div.entry > p > a[href]:has(i.fa-download)")
+        val downloadLinks = downloadAvailable.joinToString("\n") { element ->
+            val serviceText = element.text()
+            val link = element.attr("href")
+            "[$serviceText]($link)"
+        }
+
+        description = "${
+            info.html()
+                .replace("<input.*?>".toRegex(), password)
+                .replace("<.+?>".toRegex(), "")
+        }\n\n" +
+            "$view\n\n" +
+            downloadLinks
+        genre = document.parseTags()
+        status = SManga.COMPLETED
+        update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
+    }
+
+    private fun parseChapterList(document: Document, mangaUrl: String): List<SChapter> {
+        val dateUploadStr = document.selectFirst(".entry img")?.imgAttr()
+            ?.let { url ->
+                FULL_DATE_REGEX.find(url)?.groupValues?.get(1)
+                    ?: YEAR_MONTH_REGEX.find(url)?.groupValues?.get(1)?.let { "$it/01" }
             }
 
-            description = "${
-                info.html()
-                    .replace("<input.*?>".toRegex(), password)
-                    .replace("<.+?>".toRegex(), "")
-            }\n\n" +
-                "$view\n\n" +
-                downloadLinks
-            genre = document.parseTags()
-            status = SManga.COMPLETED
-            update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
+        val dateUpload = FULL_DATE_FORMAT.tryParse(dateUploadStr)
+
+        return if (preferences.splitPages) {
+            val maxPage = document.select("div.page-link:first-of-type a.post-page-numbers").last()?.text()?.toIntOrNull() ?: 1
+            (maxPage downTo 1).map { page ->
+                SChapter.create().apply {
+                    setUrlWithoutDomain("$mangaUrl/$page")
+                    name = "Page $page"
+                    chapter_number = page.toFloat()
+                    date_upload = dateUpload
+                }
+            }
+        } else {
+            listOf(
+                SChapter.create().apply {
+                    chapter_number = 0F
+                    setUrlWithoutDomain(mangaUrl)
+                    name = "Gallery"
+                    date_upload = dateUpload
+                },
+            )
         }
     }
 
-    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = client.newCall(chapterListRequest(manga))
-        .asObservableSuccess()
-        .map { response ->
-            val doc = response.asJsoup()
-            val dateUploadStr = doc.selectFirst(".entry img")?.imgAttr()
-                ?.let { url ->
-                    FULL_DATE_REGEX.find(url)?.groupValues?.get(1)
-                        ?: YEAR_MONTH_REGEX.find(url)?.groupValues?.get(1)?.let { "$it/01" }
-                }
-
-            val dateUpload = FULL_DATE_FORMAT.tryParse(dateUploadStr)
-            if (preferences.splitPages) {
-                val maxPage = doc.select("div.page-link:first-of-type a.post-page-numbers").last()?.text()?.toIntOrNull() ?: 1
-                (maxPage downTo 1).map { page ->
-                    SChapter.create().apply {
-                        setUrlWithoutDomain("${manga.url}/$page")
-                        name = "Page $page"
-                        chapter_number = page.toFloat()
-                        date_upload = dateUpload
-                    }
-                }
-            } else {
-                listOf(
-                    SChapter.create().apply {
-                        chapter_number = 0F
-                        setUrlWithoutDomain(manga.url)
-                        name = "Gallery"
-                        date_upload = dateUpload
-                    },
-                )
-            }
-        }
-
-    override fun chapterListParse(response: Response): List<SChapter> = throw UnsupportedOperationException()
-
     /* Related titles */
-    override fun relatedMangaListParse(response: Response): List<SManga> {
-        val document = response.asJsoup()
+    override val supportsRelatedMangas get() = true
+
+    override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> {
+        val document = client.get(getMangaUrl(manga)).asJsoup()
         return document.select(".content > .yarpp-related a.yarpp-thumbnail").map { element ->
             SManga.create().apply {
                 setUrlWithoutDomain(element.attr("abs:href"))
@@ -210,40 +205,34 @@ abstract class MissKon :
     // endregion
 
     // region Pages
-    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = client.newCall(pageListRequest(chapter)).asObservableSuccess()
-        .map { resp ->
-            if (preferences.splitPages) {
-                pageListParse(resp)
-            } else {
-                pageListMerge(resp)
-            }
-        }
-
     private val imageListSelector = "div.post-inner > div.entry > p > img"
 
-    override fun pageListParse(response: Response): List<Page> = response.asJsoup()
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val document = client.get(getChapterUrl(chapter)).asJsoup()
+        return if (preferences.splitPages) {
+            pageListParse(document)
+        } else {
+            pageListMerge(document)
+        }
+    }
+
+    private fun pageListParse(document: Document): List<Page> = document
         .select(imageListSelector)
         .mapIndexed { i, img -> Page(i, imageUrl = img.imgAttr()) }
 
-    private fun pageListMerge(response: Response): List<Page> {
-        val document = response.asJsoup()
+    private suspend fun pageListMerge(document: Document): List<Page> {
         val pages = document
             .select("div.page-link:first-of-type a")
-            .mapNotNull {
-                it.absUrl("href")
-            }
+            .mapNotNull { it.absUrl("href") }
 
         val chapterPage = parseImageList(document).toMutableList()
 
-        runBlocking(Dispatchers.IO) {
-            coroutineScope {
-                chapterPage += pages.map { url ->
-                    async(Dispatchers.IO) {
-                        val request = GET(url, headers)
-                        parseImageList(client.newCall(request).await().use { it.asJsoup() })
-                    }
-                }.awaitAll().flatten()
-            }
+        coroutineScope {
+            chapterPage += pages.map { url ->
+                async(Dispatchers.IO) {
+                    parseImageList(client.get(url).asJsoup())
+                }
+            }.awaitAll().flatten()
         }
 
         return chapterPage.mapIndexed { index, url ->
@@ -253,66 +242,35 @@ abstract class MissKon :
 
     private fun parseImageList(document: Document): List<String> = document.select(imageListSelector)
         .map { it.imgAttr() }
-
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
     // endregion
 
-    override fun getFilterList(): FilterList {
-        getTags()
-        return FilterList(
-            Filter.Header("NOTE: Unable to further search in the category!"),
-            Filter.Separator(),
-            TopDaysFilter("Top days", getTopDaysList()),
-            if (tagList.isEmpty()) {
-                Filter.Header("Hit refresh to load Tags")
-            } else {
-                TagsFilter("Browse Tag", tagList.toList())
-            },
-        )
-    }
-
     /* Filters */
-    private val scope = CoroutineScope(Dispatchers.IO)
-    private fun launchIO(block: () -> Unit) = scope.launch { block() }
+    override fun getFilterList(data: JsonElement?): FilterList = FilterList(
+        Filter.Header("NOTE: Unable to further search in the category!"),
+        Filter.Separator(),
+        TopDaysFilter("Top days", getTopDaysList()),
+        TagsFilter("Browse Tag", tagList.toList()),
+    )
 
-    @Volatile
-    private var tagsFetched = false
+    override val supportsFilterFetching get() = true
 
-    @Volatile
-    private var tagsFetching = false
-
-    @Volatile
-    private var tagsFetchAttempt = 0
-
-    @Synchronized
-    private fun getTags() {
-        if (tagsFetched || tagsFetching || tagsFetchAttempt >= 3) return
-        tagsFetching = true
-        tagsFetchAttempt++
-        launchIO {
-            try {
-                client.newCall(GET("$baseUrl/sets/", headers)).execute()
-                    .use { it.asJsoup() }
-                    .select(".entry .tag-counterz a[href*=/tag/]")
-                    .map {
-                        Pair(
-                            it.select("strong").text(),
-                            it.attr("href")
-                                .removeSuffix("/")
-                                .substringAfterLast('/')
-                                .let(Uri::decode),
-                        )
-                    }
-                    .let { newTags ->
-                        updateTags(newTags.toSet(), true)
-                        tagsFetched = true
-                    }
-            } catch (_: Exception) {
-            } finally {
-                tagsFetching = false
-            }
+    override suspend fun fetchFilterData(): JsonElement = client.get("$baseUrl/sets/").asJsoup()
+        .select(".entry .tag-counterz a[href*=/tag/]")
+        .map {
+            Pair(
+                it.select("strong").text(),
+                it.attr("href")
+                    .removeSuffix("/")
+                    .substringAfterLast('/')
+                    .let(Uri::decode),
+            )
         }
-    }
+        .let { newTags ->
+            updateTags(newTags.toSet(), true)
+            // we save our own pref, put empty here just so we can leverage the 3 days refresh limit
+            emptyList<String>()
+        }
+        .toJsonElement()
 
     @Volatile
     private var tagList: Set<Pair<String, String>> = DefaultTagList + loadTagListFromPreferences()
@@ -362,7 +320,6 @@ abstract class MissKon :
         hasAttr("data-original") -> absUrl("data-original")
         hasAttr("data-src") -> absUrl("data-src")
         hasAttr("data-bg") -> absUrl("data-bg")
-        hasAttr("data-srcset") -> absUrl("data-srcset")
         hasAttr("data-srcset") -> absUrl("data-srcset")
         else -> absUrl("src")
     }


### PR DESCRIPTION
## Summary by Sourcery

Migrate the MissKon extension to the newer KeiSource 1.6 API and refresh its networking, paging, and filtering behavior.

New Features:
- Support fetching full manga updates including details and chapter lists in a single operation.
- Expose related manga retrieval via the new related-manga API.
- Support server-backed filter data fetching for tags via the new filter APIs.

Enhancements:
- Refactor the source from HttpSource/Observable-based flows to suspend-based KeiSource APIs for listings and pages.
- Simplify page list merging by using structured coroutine scopes instead of custom blocking logic.
- Clean up tag management by relying on centralized filter data fetching instead of ad-hoc background coroutines.

Build:
- Bump the MissKon extension versionCode and libVersion to align with the 1.6 library release.