### PR TITLE
Enabled parallel sync for Gradle 9.4+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,6 @@ org.gradle.jvmargs=-Xmx6144m
 org.gradle.parallel=true
 
 kotlin.stdlib.default.dependency=false
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Configure org.gradle.tooling.parallel to enable parallel sync with Gradle 9.4 and newer.