### PR TITLE
3Hentai: Migrate to 1.6 & improvement

### DIFF
--- a/src/all/hentai3/build.gradle.kts
+++ b/src/all/hentai3/build.gradle.kts
@@ -6,10 +6,9 @@ plugins {
 
 keiyoushi {
     name = "3Hentai"
-    versionCode = 3
+    versionCode = 7
     contentWarning = ContentWarning.NSFW
-    libVersion = "1.4"
-    kmkVersionCode = 3
+    libVersion = "1.6"
 
     deeplink {
         host("3hentai.net")
@@ -28,9 +27,4 @@ keiyoushi {
             if (it == "pl") id = 7940950215101782907L
         }
     }
-}
-
-dependencies {
-
-    implementation(project(":lib:randomua"))
 }

--- a/src/all/hentai3/build.gradle.kts
+++ b/src/all/hentai3/build.gradle.kts
@@ -10,11 +10,6 @@ keiyoushi {
     contentWarning = ContentWarning.NSFW
     libVersion = "1.6"
 
-    deeplink {
-        host("3hentai.net")
-        path("/d/..*")
-    }
-
     listOf(
         "all", "en", "ja", "ko", "zh", "mo", "es", "pt", "id", "jv",
         "tl", "vi", "th", "my", "tr", "ru", "uk", "pl", "fi", "de",
@@ -26,5 +21,9 @@ keiyoushi {
             // lang changed from po to pl, id kept from before the rename
             if (it == "pl") id = 7940950215101782907L
         }
+    }
+
+    deeplink {
+        path("/d/..*")
     }
 }

--- a/src/all/hentai3/build.gradle.kts
+++ b/src/all/hentai3/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "3Hentai"
-    versionCode = 7
+    versionCode = 5
     contentWarning = ContentWarning.NSFW
     libVersion = "1.6"
 

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -199,7 +199,7 @@ abstract class Hentai3 :
     }
 
     private suspend fun searchMangaById(id: String): SManga {
-        if (id.toIntOrNull() == null) throw UnsupportedOperationException("ID not found")
+        if (id.toIntOrNull() == null) throw Exception("Incorrect ID")
         val document = client.get("$baseUrl/d/$id").asJsoup()
         return parseMangaDetails(document)
     }

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.extension.all.hentai3
 
 import android.webkit.CookieManager
+import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getArtists
@@ -143,9 +144,9 @@ abstract class Hentai3 :
     // Popular + Latest
     override suspend fun getPopularManga(page: Int): MangasPage {
         val url = when {
-            searchLang.isEmpty() -> "$baseUrl/search?q=pages%3A>0&sort=popular-7d&page=$page"
-            page == 1 -> "$baseUrl/language/$searchLang?sort=popular-7d"
-            else -> "$baseUrl/language/$searchLang/$page?sort=popular-7d"
+            searchLang.isEmpty() -> "$baseUrl/search?q=pages%3A>0&sort=$defaultPopularSort&page=$page"
+            page == 1 -> "$baseUrl/language/$searchLang?sort=$defaultPopularSort"
+            else -> "$baseUrl/language/$searchLang/$page?sort=$defaultPopularSort"
         }
         val doc = client.get(url).asJsoup()
         return parseMangasPage(doc)
@@ -363,15 +364,29 @@ abstract class Hentai3 :
     private val displayFullTitle
         get() = prefs.getBoolean("full_title", false)
 
+    private val defaultPopularSort
+        get() = prefs.getString(DEFAULT_POPULAR_SORT_KEY, DEFAULT_POPULAR_SORT_DEFAULT)!!
+
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {
             key = "full_title"
             title = "Display full title"
+        }.also(screen::addPreference)
+
+        ListPreference(screen.context).apply {
+            key = DEFAULT_POPULAR_SORT_KEY
+            title = "Default popular"
+            entries = popularSortsList.map { it.first }.toTypedArray()
+            entryValues = popularSortsList.map { it.second }.toTypedArray()
+            setDefaultValue(DEFAULT_POPULAR_SORT_DEFAULT)
+            summary = "%s"
         }.also(screen::addPreference)
     }
 
     companion object {
         private val SHORT_TITLE_REGEX = Regex("""(\[[^]]*]|[({][^)}]*[)}])""")
         private const val PREFIX_ID_SEARCH = "id:"
+        private const val DEFAULT_POPULAR_SORT_KEY = "default_popular_sort"
+        private const val DEFAULT_POPULAR_SORT_DEFAULT = "popular-7d"
     }
 }

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -11,33 +11,33 @@ import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getNumPages
 import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getTagDescription
 import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getTags
 import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getTime
-import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
-import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.annotation.Source
-import keiyoushi.lib.randomua.addRandomUAPreference
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.getPreferences
+import kotlinx.serialization.json.JsonElement
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import okhttp3.Request
 import okhttp3.Response
+import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import rx.Observable
 import java.io.IOException
 
 @Source
 abstract class Hentai3 :
-    HttpSource(),
+    KeiSource(),
     ConfigurableSource {
 
     private val searchLang: String
@@ -106,8 +106,6 @@ abstract class Hentai3 :
             else -> ""
         }
 
-    override val supportsLatest = true
-
     private val webViewCookieManager: CookieManager by lazy { CookieManager.getInstance() }
 
     val cookies
@@ -124,15 +122,9 @@ abstract class Hentai3 :
             }
             ?: emptyList()
 
-    override val client: OkHttpClient by lazy {
-        network.client.newBuilder()
-            .addNetworkInterceptor(::authorizationInterceptor)
-            .build()
+    override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = apply {
+        addNetworkInterceptor(::authorizationInterceptor)
     }
-
-    override fun headersBuilder() = super.headersBuilder()
-        .set("Referer", "$baseUrl/")
-        .set("Origin", baseUrl)
 
     fun authorizationInterceptor(chain: Interceptor.Chain): Response {
         val request = chain.request().newBuilder()
@@ -160,31 +152,28 @@ abstract class Hentai3 :
                 true
             }
         }.also(screen::addPreference)
-
-        screen.addRandomUAPreference()
     }
 
     // Popular
-    override fun popularMangaRequest(page: Int): Request = GET(
-        when {
+    override suspend fun getPopularManga(page: Int): MangasPage {
+        val url = when {
             searchLang.isBlank() -> "$baseUrl/search?q=pages%3A>0&sort=popular-7d&page=$page"
             page == 1 -> "$baseUrl/language/$searchLang?sort=popular-7d"
             else -> "$baseUrl/language/$searchLang/$page?sort=popular-7d"
-        },
-        headers,
-    )
+        }
 
-    override fun popularMangaParse(response: Response): MangasPage {
-        val doc = response.asJsoup()
+        return parseMangasPage(client.get(url).asJsoup())
+    }
 
-        val mangas = doc.select(popularMangaSelector()).map(::popularMangaFromElement)
-        val hasNextPage = doc.selectFirst(popularMangaNextPageSelector()) != null
+    private fun parseMangasPage(document: Document): MangasPage {
+        val mangas = document.select(popularMangaSelector).map(::popularMangaFromElement)
+        val hasNextPage = document.selectFirst(popularMangaNextPageSelector) != null
 
         return MangasPage(mangas, hasNextPage)
     }
 
-    private fun popularMangaSelector() = "a[href*=/d/]"
-    private fun popularMangaNextPageSelector() = "a[rel=next]"
+    private val popularMangaSelector = "a[href*=/d/]"
+    private val popularMangaNextPageSelector = "a[rel=next]"
 
     private fun popularMangaFromElement(element: Element): SManga = SManga.create().apply {
         title = element.selectFirst("div.title")!!.ownText().replace("\"", "").let {
@@ -196,53 +185,53 @@ abstract class Hentai3 :
         }
     }
 
-    private fun relatedMangaListSelector(): String = popularMangaSelector() + if (flagLang.isNotEmpty()) ":has(.flag-$flagLang)" else ""
+    // Related
+    override val supportsRelatedMangas get() = true
 
-    override fun relatedMangaListParse(response: Response): List<SManga> = response.asJsoup()
+    private fun relatedMangaListSelector(): String = popularMangaSelector + if (flagLang.isNotEmpty()) ":has(.flag-$flagLang)" else ""
+
+    override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> = client.get(getMangaUrl(manga)).asJsoup()
         .select(relatedMangaListSelector()).map(::popularMangaFromElement)
 
     // Latest
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/${if (searchLang.isNotEmpty()) "language/$searchLang/$page" else "search?q=pages%3A>0&page=$page"}", headers)
-
-    override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
+        val url = "$baseUrl/${if (searchLang.isNotEmpty()) "language/$searchLang/$page" else "search?q=pages%3A>0&page=$page"}"
+        return parseMangasPage(client.get(url).asJsoup())
+    }
 
     // Search
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
-        if (query.startsWith("https://")) {
-            val url = query.toHttpUrl()
-            if (url.host != baseUrl.toHttpUrl().host || url.pathSegments.size < 2) {
-                throw Exception("Unsupported url")
-            }
-            val id = url.pathSegments[1]
-            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$id", filters)
-        }
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = when {
+        query.startsWith(PREFIX_ID_SEARCH) -> MangasPage(listOf(searchMangaById(query.removePrefix(PREFIX_ID_SEARCH))), false)
+        query.toIntOrNull() != null -> MangasPage(listOf(searchMangaById(query)), false)
+        else -> {
+            val response = client.get(searchMangaRequestUrl(page, query, filters))
+            val document = response.asJsoup()
 
-        return when {
-            query.startsWith(PREFIX_ID_SEARCH) -> {
-                val id = query.removePrefix(PREFIX_ID_SEARCH)
-                client.newCall(searchMangaByIdRequest(id))
-                    .asObservableSuccess()
-                    .map { response -> searchMangaByIdParse(response, id) }
+            if (response.request.url.toString().contains("/login") &&
+                document.select("input[value=Login to my account]").isNotEmpty()
+            ) {
+                throw Exception("Log in via WebView to view favorites")
             }
-            query.toIntOrNull() != null -> {
-                client.newCall(searchMangaByIdRequest(query))
-                    .asObservableSuccess()
-                    .map { response -> searchMangaByIdParse(response, query) }
-            }
-            else -> super.fetchSearchManga(page, query, filters)
+
+            parseMangasPage(document)
         }
     }
 
-    private fun searchMangaByIdRequest(id: String) = GET("$baseUrl/d/$id", headers)
-
-    private fun searchMangaByIdParse(response: Response, id: String): MangasPage {
-        val details = mangaDetailsParse(response)
-        details.url = "/d/$id"
-        return MangasPage(listOf(details), false)
+    private suspend fun searchMangaById(id: String): SManga {
+        val document = client.get("$baseUrl/d/$id").asJsoup()
+        return parseMangaDetails(document).apply { url = "/d/$id" }
     }
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.host != baseUrl.toHttpUrl().host || url.pathSegments.size < 2) {
+            return null
+        }
+
+        return searchMangaById(url.pathSegments[1])
+    }
+
+    private fun searchMangaRequestUrl(page: Int, query: String, filters: FilterList): HttpUrl {
         val filterList = if (filters.isEmpty()) getFilterList() else filters
         val queries = (
             listOfNotNull(
@@ -264,15 +253,13 @@ abstract class Hentai3 :
             "$baseUrl/search"
         }
 
-        val url = searchURL.toHttpUrl().newBuilder().apply {
+        return searchURL.toHttpUrl().newBuilder().apply {
             addQueryParameter("q", queries.ifEmpty { "pages:>0" })
             addQueryParameter("page", offsetPage.toString())
             filterList.firstInstanceOrNull<SelectFilter>()?.let { f ->
                 addQueryParameter("sort", f.getValue())
             }
-        }
-
-        return GET(url.build(), headers)
+        }.build()
     }
 
     private fun combineQuery(filters: FilterList): List<String> {
@@ -308,23 +295,9 @@ abstract class Hentai3 :
 
     data class AdvSearchEntry(val type: String, val text: String, val exclude: Boolean, val specific: String)
 
-    override fun searchMangaParse(response: Response): MangasPage {
-        if (response.request.url.toString().contains("/login")) {
-            val document = response.asJsoup()
-            if (document.select("input[value=Login to my account]").isNotEmpty()) {
-                throw Exception("Log in via WebView to view favorites")
-            }
-        }
-
-        return popularMangaParse(response)
-    }
-
     // Details
 
-    override fun getMangaUrl(manga: SManga) = "$baseUrl${manga.url}"
-
-    override fun mangaDetailsParse(response: Response): SManga {
-        val document = response.asJsoup()
+    private fun parseMangaDetails(document: Document): SManga {
         val fullTitle = document.select("#main-info > h1").text()
             .replace("\"", "").trim()
 
@@ -358,29 +331,40 @@ abstract class Hentai3 :
 
     // Chapters
 
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val doc = response.asJsoup()
-        return listOf(
-            SChapter.create().apply {
-                name = "Chapter"
-                setUrlWithoutDomain(response.request.url.toString())
-                date_upload = getTime(doc)
-            },
-        )
+    private fun parseChapterList(document: Document, chapterUrl: String): List<SChapter> = listOf(
+        SChapter.create().apply {
+            name = "Chapter"
+            setUrlWithoutDomain(chapterUrl)
+            date_upload = getTime(document)
+        },
+    )
+
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val mangaUrl = getMangaUrl(manga)
+        val document = client.get(mangaUrl).asJsoup()
+
+        val updatedManga = parseMangaDetails(document).apply { url = manga.url }
+        val updatedChapters = parseChapterList(document, mangaUrl)
+
+        return SMangaUpdate(updatedManga, updatedChapters)
     }
 
     // Pages
 
-    override fun pageListParse(response: Response): List<Page> {
-        val images = response.asJsoup().select("#thumbnail-gallery .single-thumb a > img")
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val images = client.get(getChapterUrl(chapter)).asJsoup().select("#thumbnail-gallery .single-thumb a > img")
         return images.mapIndexed { index, image ->
             val imageUrl = image.attr("abs:data-src")
             Page(index, imageUrl = imageUrl.replace("t.", "."))
         }
     }
 
-    override fun getFilterList() = getFilters()
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
+    override fun getFilterList(data: JsonElement?) = getFilters()
 
     private val shortenTitleRegex = Regex("""(\[[^]]*]|[({][^)}]*[)}])""")
     private fun String.shortenTitle() = this.replace(shortenTitleRegex, "").trim()

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -5,9 +5,9 @@ import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getArtists
 import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getCodes
+import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getDescriptions
 import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getGroups
 import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getNumPages
-import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getTagDescription
 import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getTags
 import eu.kanade.tachiyomi.extension.all.hentai3.Hentai3Utils.getTime
 import eu.kanade.tachiyomi.source.ConfigurableSource
@@ -143,17 +143,22 @@ abstract class Hentai3 :
     // Popular + Latest
     override suspend fun getPopularManga(page: Int): MangasPage {
         val url = when {
-            searchLang.isBlank() -> "$baseUrl/search?q=pages%3A>0&sort=popular-7d&page=$page"
+            searchLang.isEmpty() -> "$baseUrl/search?q=pages%3A>0&sort=popular-7d&page=$page"
             page == 1 -> "$baseUrl/language/$searchLang?sort=popular-7d"
             else -> "$baseUrl/language/$searchLang/$page?sort=popular-7d"
         }
-
-        return parseMangasPage(client.get(url).asJsoup())
+        val doc = client.get(url).asJsoup()
+        return parseMangasPage(doc)
     }
 
     override suspend fun getLatestUpdates(page: Int): MangasPage {
-        val url = "$baseUrl/${if (searchLang.isNotEmpty()) "language/$searchLang/$page" else "search?q=pages%3A>0&page=$page"}"
-        return parseMangasPage(client.get(url).asJsoup())
+        val url = if (searchLang.isNotEmpty()) {
+            "$baseUrl/language/$searchLang/$page"
+        } else {
+            "$baseUrl/search?q=pages%3A>0&page=$page"
+        }
+        val doc = client.get(url).asJsoup()
+        return parseMangasPage(doc)
     }
 
     private fun parseMangasPage(document: Document): MangasPage {
@@ -167,23 +172,22 @@ abstract class Hentai3 :
     private val popularMangaNextPageSelector = "a[rel=next]"
 
     private fun popularMangaFromElement(element: Element): SManga = SManga.create().apply {
-        title = element.selectFirst("div.title")!!.ownText().replace("\"", "")
+        title = element.selectFirst("div.title")!!.ownText()
+            .replace("\"", "")
             .shortenTitle()
         setUrlWithoutDomain(element.absUrl("href"))
-        thumbnail_url = element.selectFirst(".cover img")!!.let { img ->
-            if (img.hasAttr("data-src")) img.attr("abs:data-src") else img.absUrl("src")
-        }
+        thumbnail_url = element.selectFirst(".cover img")?.getImage()
     }
 
     // Search
     override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = when {
         query.startsWith(PREFIX_ID_SEARCH) -> MangasPage(listOf(searchMangaById(query.removePrefix(PREFIX_ID_SEARCH))), false)
-        query.toIntOrNull() != null -> MangasPage(listOf(searchMangaById(query)), false)
         else -> {
-            val response = client.get(searchMangaRequestUrl(page, query, filters))
+            val url = searchMangaRequestUrl(page, query, filters)
+            val response = client.get(url)
             val document = response.asJsoup()
 
-            if (response.request.url.toString().contains("/login") &&
+            if (url.toString().contains("/login") &&
                 document.select("input[value=Login to my account]").isNotEmpty()
             ) {
                 throw Exception("Log in via WebView to view favorites")
@@ -194,8 +198,9 @@ abstract class Hentai3 :
     }
 
     private suspend fun searchMangaById(id: String): SManga {
+        if (id.toIntOrNull() == null) throw UnsupportedOperationException("ID not found")
         val document = client.get("$baseUrl/d/$id").asJsoup()
-        return parseMangaDetails(document).apply { url = "/d/$id" }
+        return parseMangaDetails(document)
     }
 
     private fun searchMangaRequestUrl(page: Int, query: String, filters: FilterList): HttpUrl {
@@ -262,46 +267,47 @@ abstract class Hentai3 :
 
     data class AdvSearchEntry(val type: String, val text: String, val exclude: Boolean, val specific: String)
 
-    override fun getFilterList(data: JsonElement?) = getFilters()
+    override fun getFilterList(data: JsonElement?): FilterList = getFilters()
 
     // Details + Chapters
     override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
-        if (url.host != baseUrl.toHttpUrl().host || url.pathSegments.size < 2) {
-            return null
-        }
+        if (url.host != baseUrl.toHttpUrl().host) return null
+        if (url.pathSegments.getOrNull(0) != "d") return null
 
-        return searchMangaById(url.pathSegments[1])
+        return url.pathSegments.getOrNull(1)?.let { searchMangaById(it) }
     }
 
     private fun parseMangaDetails(document: Document): SManga {
         val fullTitle = document.select("#main-info > h1").text()
             .replace("\"", "").trim()
+        val shortTitle = document.select("#main-info > h1 > span").text()
+            .replace("\"", "").trim()
+            .takeIf { !displayFullTitle && it.isNotEmpty() }
 
         return SManga.create().apply {
-            val authors = getGroups(document) ?: ""
-            val artists = getArtists(document) ?: ""
+            setUrlWithoutDomain(document.location())
+
+            val authors = getGroups(document)
+            val artists = getArtists(document)
             initialized = true
 
-            title = if (displayFullTitle) {
-                fullTitle
-            } else {
-                document.select("#main-info > h1 > span").text()
-                    .replace("\"", "").trim()
-                    .ifBlank { fullTitle.shortenTitle() }
-            }
-            author = authors.ifEmpty { artists }
-            artist = artists.ifEmpty { authors }
+            title = shortTitle ?: fullTitle.shortenTitle()
+
+            author = authors ?: artists
+            artist = artists ?: authors
+
             val code = getCodes(document)
             // Some people want these additional details in description
             description = "Full English and Japanese titles:\n"
                 .plus("$fullTitle\n\n")
                 .plus(code ?: "")
                 .plus("Pages: ${getNumPages(document)}\n")
-                .plus(getTagDescription(document))
+                .plus(getDescriptions(document))
             genre = getTags(document)
-            thumbnail_url = document.select("#main-cover img").attr("data-src")
-            update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
+
+            thumbnail_url = document.selectFirst("#main-cover img")?.getImage()
             status = SManga.COMPLETED
+            update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
         }
     }
 
@@ -322,14 +328,14 @@ abstract class Hentai3 :
         val mangaUrl = getMangaUrl(manga)
         val document = client.get(mangaUrl).asJsoup()
 
-        val updatedManga = parseMangaDetails(document).apply { url = manga.url }
+        val updatedManga = parseMangaDetails(document)
         val updatedChapters = parseChapterList(document, mangaUrl)
 
         return SMangaUpdate(updatedManga, updatedChapters)
     }
 
     // Related manga
-    override val supportsRelatedMangas get() = true
+    override val supportsRelatedMangas = true
 
     private fun relatedMangaListSelector(): String = popularMangaSelector + if (flagLang.isNotEmpty()) ":has(.flag-$flagLang)" else ""
 
@@ -338,16 +344,18 @@ abstract class Hentai3 :
 
     // Pages
     override suspend fun getPageList(chapter: SChapter): List<Page> {
-        val images = client.get(getChapterUrl(chapter)).asJsoup().select("#thumbnail-gallery .single-thumb a > img")
-        return images.mapIndexed { index, image ->
-            val imageUrl = image.attr("abs:data-src")
-            Page(index, imageUrl = imageUrl.replace("t.", "."))
-        }
+        val doc = client.get(getChapterUrl(chapter)).asJsoup()
+        return doc.select("#thumbnail-gallery .single-thumb a > img")
+            .mapIndexed { index, image ->
+                Page(index, imageUrl = image.getImage())
+            }
     }
+
+    private fun Element.getImage(): String = attr("abs:data-src").ifEmpty { absUrl("src") }.replace("t.", ".")
 
     // Preferences
     private fun String.shortenTitle() = if (displayFullTitle) {
-        this
+        trim()
     } else {
         replace(SHORT_TITLE_REGEX, "").trim()
     }

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.all.hentai3
 
-import android.content.SharedPreferences
 import android.webkit.CookieManager
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
@@ -24,7 +23,7 @@ import keiyoushi.annotation.Source
 import keiyoushi.network.get
 import keiyoushi.source.KeiSource
 import keiyoushi.utils.firstInstanceOrNull
-import keiyoushi.utils.getPreferences
+import keiyoushi.utils.getPreferencesLazy
 import kotlinx.serialization.json.JsonElement
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -139,22 +138,9 @@ abstract class Hentai3 :
         return response
     }
 
-    private val prefs: SharedPreferences by lazy { getPreferences() }
+    private val prefs by getPreferencesLazy()
 
-    private var displayFullTitle: Boolean = prefs.getBoolean("full_title", false)
-
-    override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        SwitchPreferenceCompat(screen.context).apply {
-            key = "full_title"
-            title = "Display full title"
-            setOnPreferenceChangeListener { _, newValue ->
-                displayFullTitle = newValue as Boolean
-                true
-            }
-        }.also(screen::addPreference)
-    }
-
-    // Popular
+    // Popular + Latest
     override suspend fun getPopularManga(page: Int): MangasPage {
         val url = when {
             searchLang.isBlank() -> "$baseUrl/search?q=pages%3A>0&sort=popular-7d&page=$page"
@@ -162,6 +148,11 @@ abstract class Hentai3 :
             else -> "$baseUrl/language/$searchLang/$page?sort=popular-7d"
         }
 
+        return parseMangasPage(client.get(url).asJsoup())
+    }
+
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
+        val url = "$baseUrl/${if (searchLang.isNotEmpty()) "language/$searchLang/$page" else "search?q=pages%3A>0&page=$page"}"
         return parseMangasPage(client.get(url).asJsoup())
     }
 
@@ -176,31 +167,15 @@ abstract class Hentai3 :
     private val popularMangaNextPageSelector = "a[rel=next]"
 
     private fun popularMangaFromElement(element: Element): SManga = SManga.create().apply {
-        title = element.selectFirst("div.title")!!.ownText().replace("\"", "").let {
-            if (displayFullTitle) it.trim() else it.shortenTitle()
-        }
+        title = element.selectFirst("div.title")!!.ownText().replace("\"", "")
+            .shortenTitle()
         setUrlWithoutDomain(element.absUrl("href"))
         thumbnail_url = element.selectFirst(".cover img")!!.let { img ->
             if (img.hasAttr("data-src")) img.attr("abs:data-src") else img.absUrl("src")
         }
     }
 
-    // Related
-    override val supportsRelatedMangas get() = true
-
-    private fun relatedMangaListSelector(): String = popularMangaSelector + if (flagLang.isNotEmpty()) ":has(.flag-$flagLang)" else ""
-
-    override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> = client.get(getMangaUrl(manga)).asJsoup()
-        .select(relatedMangaListSelector()).map(::popularMangaFromElement)
-
-    // Latest
-    override suspend fun getLatestUpdates(page: Int): MangasPage {
-        val url = "$baseUrl/${if (searchLang.isNotEmpty()) "language/$searchLang/$page" else "search?q=pages%3A>0&page=$page"}"
-        return parseMangasPage(client.get(url).asJsoup())
-    }
-
     // Search
-
     override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = when {
         query.startsWith(PREFIX_ID_SEARCH) -> MangasPage(listOf(searchMangaById(query.removePrefix(PREFIX_ID_SEARCH))), false)
         query.toIntOrNull() != null -> MangasPage(listOf(searchMangaById(query)), false)
@@ -221,14 +196,6 @@ abstract class Hentai3 :
     private suspend fun searchMangaById(id: String): SManga {
         val document = client.get("$baseUrl/d/$id").asJsoup()
         return parseMangaDetails(document).apply { url = "/d/$id" }
-    }
-
-    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
-        if (url.host != baseUrl.toHttpUrl().host || url.pathSegments.size < 2) {
-            return null
-        }
-
-        return searchMangaById(url.pathSegments[1])
     }
 
     private fun searchMangaRequestUrl(page: Int, query: String, filters: FilterList): HttpUrl {
@@ -295,7 +262,16 @@ abstract class Hentai3 :
 
     data class AdvSearchEntry(val type: String, val text: String, val exclude: Boolean, val specific: String)
 
-    // Details
+    override fun getFilterList(data: JsonElement?) = getFilters()
+
+    // Details + Chapters
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.host != baseUrl.toHttpUrl().host || url.pathSegments.size < 2) {
+            return null
+        }
+
+        return searchMangaById(url.pathSegments[1])
+    }
 
     private fun parseMangaDetails(document: Document): SManga {
         val fullTitle = document.select("#main-info > h1").text()
@@ -329,8 +305,6 @@ abstract class Hentai3 :
         }
     }
 
-    // Chapters
-
     private fun parseChapterList(document: Document, chapterUrl: String): List<SChapter> = listOf(
         SChapter.create().apply {
             name = "Chapter"
@@ -354,8 +328,15 @@ abstract class Hentai3 :
         return SMangaUpdate(updatedManga, updatedChapters)
     }
 
-    // Pages
+    // Related manga
+    override val supportsRelatedMangas get() = true
 
+    private fun relatedMangaListSelector(): String = popularMangaSelector + if (flagLang.isNotEmpty()) ":has(.flag-$flagLang)" else ""
+
+    override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> = client.get(getMangaUrl(manga)).asJsoup()
+        .select(relatedMangaListSelector()).map(::popularMangaFromElement)
+
+    // Pages
     override suspend fun getPageList(chapter: SChapter): List<Page> {
         val images = client.get(getChapterUrl(chapter)).asJsoup().select("#thumbnail-gallery .single-thumb a > img")
         return images.mapIndexed { index, image ->
@@ -364,12 +345,25 @@ abstract class Hentai3 :
         }
     }
 
-    override fun getFilterList(data: JsonElement?) = getFilters()
+    // Preferences
+    private fun String.shortenTitle() = if (displayFullTitle) {
+        this
+    } else {
+        replace(SHORT_TITLE_REGEX, "").trim()
+    }
 
-    private val shortenTitleRegex = Regex("""(\[[^]]*]|[({][^)}]*[)}])""")
-    private fun String.shortenTitle() = this.replace(shortenTitleRegex, "").trim()
+    private val displayFullTitle
+        get() = prefs.getBoolean("full_title", false)
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        SwitchPreferenceCompat(screen.context).apply {
+            key = "full_title"
+            title = "Display full title"
+        }.also(screen::addPreference)
+    }
 
     companion object {
-        const val PREFIX_ID_SEARCH = "id:"
+        private val SHORT_TITLE_REGEX = Regex("""(\[[^]]*]|[({][^)}]*[)}])""")
+        private const val PREFIX_ID_SEARCH = "id:"
     }
 }

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -77,7 +77,7 @@ abstract class Hentai3 :
     private val flagLang: String
         get() = when (lang) {
             "all" -> ""
-            "en" -> "en"
+            "en" -> "eng"
             "ja" -> "jpn"
             "ko" -> "kor"
             "zh" -> "zho"

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -188,10 +188,10 @@ abstract class Hentai3 :
             val response = client.get(url)
             val document = response.asJsoup()
 
-            if (url.toString().contains("/login") &&
+            if (response.request.url.toString().contains("/login") &&
                 document.select("input[value=Login to my account]").isNotEmpty()
             ) {
-                throw Exception("Log in via WebView to view favorites")
+                throw IOException("Log in via WebView to view favorites")
             }
 
             parseMangasPage(document)

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -338,7 +338,11 @@ abstract class Hentai3 :
     // Related manga
     override val supportsRelatedMangas = true
 
-    private fun relatedMangaListSelector(): String = popularMangaSelector + if (flagLang.isNotEmpty()) ":has(.flag-$flagLang)" else ""
+    private fun relatedMangaListSelector(): String = if (flagLang.isNotEmpty()) {
+        "$popularMangaSelector:has(.title.flag-$flagLang), $popularMangaSelector:has(.title:not(.flag))"
+    } else {
+        popularMangaSelector
+    }
 
     override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> = client.get(getMangaUrl(manga)).asJsoup()
         .select(relatedMangaListSelector()).map(::popularMangaFromElement)

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3Filters.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3Filters.kt
@@ -40,11 +40,11 @@ internal open class SelectFilter(name: String, private val vals: List<Pair<Strin
     fun getValue() = vals[state].second
 }
 
-val popularSortsList: List<Pair<String, String>> = listOf(
+internal val popularSortsList: List<Pair<String, String>> = listOf(
     Pair("Popular: All Time", "popular"),
     Pair("Popular: Month", "popular-30d"),
     Pair("Popular: Week", "popular-7d"),
     Pair("Popular: Today", "popular-24h"),
 )
 
-private val getSortsList: List<Pair<String, String>> = listOf(Pair("Recent", "")) + popularSortsList
+internal val getSortsList: List<Pair<String, String>> = listOf(Pair("Recent", "")) + popularSortsList

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3Filters.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3Filters.kt
@@ -26,6 +26,8 @@ fun getFilters(): FilterList = FilterList(
     TextFilter("Pages", "pages"),
     OffsetPageFilter(),
     FavoriteFilter(),
+    Filter.Separator(),
+    Filter.Header("Search manga directly with `id:<code>`"),
 )
 
 internal open class TextFilter(name: String, val type: String, val specific: String = "") : Filter.Text(name)

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3Filters.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3Filters.kt
@@ -41,6 +41,7 @@ internal open class SelectFilter(name: String, private val vals: List<Pair<Strin
 private val getSortsList: List<Pair<String, String>> = listOf(
     Pair("Recent", ""),
     Pair("Popular: All Time", "popular"),
+    Pair("Popular: Month", "popular-30d"),
     Pair("Popular: Week", "popular-7d"),
     Pair("Popular: Today", "popular-24h"),
 )

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3Filters.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3Filters.kt
@@ -38,10 +38,11 @@ internal open class SelectFilter(name: String, private val vals: List<Pair<Strin
     fun getValue() = vals[state].second
 }
 
-private val getSortsList: List<Pair<String, String>> = listOf(
-    Pair("Recent", ""),
+val popularSortsList: List<Pair<String, String>> = listOf(
     Pair("Popular: All Time", "popular"),
     Pair("Popular: Month", "popular-30d"),
     Pair("Popular: Week", "popular-7d"),
     Pair("Popular: Today", "popular-24h"),
 )
+
+private val getSortsList: List<Pair<String, String>> = listOf(Pair("Recent", "")) + popularSortsList

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3Utils.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3Utils.kt
@@ -27,7 +27,7 @@ internal object Hentai3Utils {
         }
     }
 
-    fun getTagDescription(document: Document): String {
+    fun getDescriptions(document: Document): String {
         val stringBuilder = StringBuilder()
 
         // "a[href*=/category/]"
@@ -35,8 +35,17 @@ internal object Hentai3Utils {
         if (categories.isNotEmpty()) {
             stringBuilder.append("Categories: ")
             stringBuilder.append(categories.joinToString { it.cleanTag() })
-            stringBuilder.append("\n\n")
+            stringBuilder.append("\n")
         }
+
+        // "a[href*=/group/]"
+        val groups = getGroups(document)
+        if (!groups.isNullOrBlank()) {
+            stringBuilder.append("Groups: ")
+            stringBuilder.append(groups)
+            stringBuilder.append("\n")
+        }
+        stringBuilder.append("\n")
 
         // "a[href*=/series/]"
         val series = document.select("#main-info > div.tag-container:contains(Series) > .filter-elem > a.name")
@@ -80,10 +89,6 @@ internal object Hentai3Utils {
 
         return SimpleDateFormat("yyyy-MM-dd HH:mm:ssZ", Locale.getDefault()).tryParse(timeString)
     }
-
-//    val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZZZZ", Locale.ENGLISH).apply {
-//        timeZone = TimeZone.getTimeZone("UTC")
-//    }
 
     fun getCodes(document: Document): String? {
         val codes = document.select("#main-info > h3 > strong")


### PR DESCRIPTION
* Add popular-month
* Add pref for selecting default popular
* Fix "eng" related
* Include `speechless` in related
* Add `Groups` to description
* Remove random user-agent

## Summary by Sourcery

Migrate the 3Hentai extension to the newer KeiSource 1.6 API while updating browsing, search, and details behavior.

New Features:
- Add configurable default sort option for popular manga, including a new month-based popularity sort.
- Support direct ID-based search via an `id:<code>` hint in the search filters and URL-based manga resolution.
- Expose related manga through the new related-manga API with language-aware selection and inclusion of non-flagged titles.
- Extend manga descriptions to include categories, series, and groups metadata.

Bug Fixes:
- Correct language flag mapping to use `eng` for English, fixing English-related filtering and related-manga selection.
- Require login in WebView before accessing favorites when the search endpoint redirects to the login page.

Enhancements:
- Replace the old HttpSource implementation with KeiSource APIs, simplifying networking, pagination, and updates.
- Unify popular and latest parsing logic, centralizing list extraction and thumbnail handling.
- Refine title handling and preferences so short titles are used by default while still allowing full titles via a setting.
- Improve image URL handling for thumbnails and pages to more robustly resolve source URLs and strip thumbnail markers.
- Remove the random user-agent dependency and related configuration from the extension.

Build:
- Bump extension versionCode and library version to 1.6 and simplify the Gradle configuration and deeplink setup.