### PR TITLE
beta

### DIFF
--- a/.github/scripts/publish-repo.py
+++ b/.github/scripts/publish-repo.py
@@ -30,10 +30,6 @@ RELEASE_BASE_URL = f"https://github.com/{REPO_NAME}/releases/download"
 ASSET_LIMIT = 495  # Actual limit is 1000 but we upload 2 items per extension.
 RETRY_ATTEMPTS = 4
 RETRY_BASE_DELAY = 60  # Documented minimum wait; doubles per attempt.
-# Uploading continuously trips a secondary rate limit after roughly 450 assets, and
-# that limit clears again within a few minutes. Pace the uploads well under the rate
-# that trips it. Small calls also cap how much completed work gh re-sends on retry,
-# since it re-uploads the whole call.
 UPLOAD_CHUNK_SIZE = 80
 UPLOAD_CHUNK_INTERVAL = 30
 
@@ -252,7 +248,7 @@ def write_index(filename: str, index: index_pb2.Index):
         )
 
     with REPO_DIR.joinpath(f"{filename}.pb").open("wb") as f:
-        f.write(gzip.compress(index.SerializeToString(deterministic=True)))
+        f.write(gzip.compress(index.SerializeToString(deterministic=True), mtime=0))
 
 
 index = create_index("Yūzōnō", "Yū", all_extensions)
@@ -279,7 +275,7 @@ if not new_extensions:
     sys.exit(0)
 
 
-def run_gh(*args: str, success_codes: tuple[int, ...] = ()) -> str:
+def run_gh(*args: str, success_errors: tuple[str, ...] = ()) -> str:
     delay = RETRY_BASE_DELAY
     for attempt in range(1, RETRY_ATTEMPTS + 1):
         result = subprocess.run(
@@ -288,22 +284,48 @@ def run_gh(*args: str, success_codes: tuple[int, ...] = ()) -> str:
             text=True,
             check=False,
         )
-        if result.returncode == 0 or result.returncode in success_codes:
+        if result.returncode == 0:
             return result.stdout.strip()
 
-        # Secondary rate limits are explicitly retryable after a wait; everything else
-        # is a real failure, so fail fast. The upload endpoint sends no retry-after
-        # header, so back off from the documented one minute minimum.
+        error = result.stderr.lower()
+
+        # The upload endpoint does not expose retry headers through gh, so use the
+        # documented one-minute minimum with exponential backoff for secondary limits.
         # https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
-        if attempt < RETRY_ATTEMPTS and "secondary rate limit" in result.stderr.lower():
+        if "secondary rate limit" in error:
+            if attempt < RETRY_ATTEMPTS:
+                print(
+                    f"secondary rate limit hit, retrying in {delay}s "
+                    f"(attempt {attempt}/{RETRY_ATTEMPTS})",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+                delay *= 2
+                continue
+
+        elif "api rate limit exceeded" in error and attempt < RETRY_ATTEMPTS:
+            rate_limit = subprocess.run(
+                ["gh", "api", "rate_limit", "--jq", ".resources.core.reset"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            retry_delay = RETRY_BASE_DELAY
+            if rate_limit.returncode == 0:
+                retry_delay = max(
+                    int(rate_limit.stdout.strip()) - int(time.time()) + 10,
+                    RETRY_BASE_DELAY,
+                )
             print(
-                f"secondary rate limit hit, retrying in {delay}s "
+                f"API rate limit hit, retrying in {retry_delay}s "
                 f"(attempt {attempt}/{RETRY_ATTEMPTS})",
                 file=sys.stderr,
             )
-            time.sleep(delay)
-            delay *= 2
+            time.sleep(retry_delay)
             continue
+
+        elif any(success_error in error for success_error in success_errors):
+            return result.stdout.strip()
 
         print(f"gh {' '.join(args)} failed: {result.stderr}", file=sys.stderr)
         sys.exit(result.returncode)
@@ -318,7 +340,7 @@ def create_release(tag: str):
         REPO_NAME,
         "--json",
         "tagName",
-        success_codes=(1,),
+        success_errors=("release not found",),
     ):
         print(f"Release {tag} already exists")
         return
@@ -343,15 +365,43 @@ def publish_release(tag: str):
     run_gh("release", "edit", tag, "--repo", REPO_NAME, "--draft=false")
 
 
+def get_release_assets(tag: str) -> dict[str, str]:
+    release = json.loads(
+        run_gh(
+            "release",
+            "view",
+            tag,
+            "--repo",
+            REPO_NAME,
+            "--json",
+            "assets",
+        )
+    )
+    return {
+        asset["name"]: (asset.get("digest") or "").removeprefix("sha256:")
+        for asset in release["assets"]
+    }
+
+
 def upload_assets(tag: str, files: list[Path]):
     if not files:
         return
-    print(f"Uploading {len(files)} assets to {tag}")
-    for i in range(0, len(files), UPLOAD_CHUNK_SIZE):
-        chunk = files[i : i + UPLOAD_CHUNK_SIZE]
+
+    existing_assets = get_release_assets(tag)
+    files_to_upload = [
+        file
+        for file in files
+        if existing_assets.get(file.name)
+        != hashlib.sha256(file.read_bytes()).hexdigest()
+    ]
+    skipped = len(files) - len(files_to_upload)
+    print(f"Uploading {len(files_to_upload)} assets to {tag}, skipping {skipped}")
+
+    for i in range(0, len(files_to_upload), UPLOAD_CHUNK_SIZE):
+        chunk = files_to_upload[i : i + UPLOAD_CHUNK_SIZE]
         if i:
             time.sleep(UPLOAD_CHUNK_INTERVAL)
-        print(f"  assets {i + 1}-{i + len(chunk)} of {len(files)}")
+        print(f"  assets {i + 1}-{i + len(chunk)} of {len(files_to_upload)}")
         run_gh(
             "release",
             "upload",

--- a/.github/scripts/publish-repo.py
+++ b/.github/scripts/publish-repo.py
@@ -1,12 +1,14 @@
 import gzip
+import hashlib
 import html
 import json
+import math
+import subprocess
 import sys
 from pathlib import Path
 
-from google.protobuf import json_format
-
 import index_pb2
+from google.protobuf import json_format
 
 # Artifacts downloaded from the build jobs: one APK per extension plus the source metadata JSON
 # emitted by each assembleRelease.
@@ -22,22 +24,43 @@ REPO_JAR_DIR.mkdir(parents=True, exist_ok=True)
 APK_BASE_URL = "https://cdn.jsdelivr.net/gh/yuzono/manga-repo@repo/apk"
 JAR_BASE_URL = "https://raw.githubusercontent.com/yuzono/manga-repo/repo/jar"
 ICON_BASE_URL = "https://cdn.jsdelivr.net/gh/yuzono/tachiyomi-extensions@master"
+REPO_NAME = "yuzono/manga-repo"
+RELEASE_BASE_URL = f"https://github.com/{REPO_NAME}/releases/download"
+ASSET_LIMIT = 495  # Actual limit is 1000 but we upload 2 items per extension.
 
 to_delete: list[str] = json.loads(sys.argv[1])
+current_sha = sys.argv[2]
+current_sha_short = current_sha[:7]
 
-# Drop apks/icons for modules that were deleted or rebuilt (rebuilt ones are re-added below).
-for module in to_delete:
-    for file in REPO_APK_DIR.glob(f"tachiyomi-{module}-v*.*.*.apk"):
-        print(f"removing {file.name}")
-        file.unlink(missing_ok=True)
-    for file in REPO_JAR_DIR.glob(f"tachiyomi-{module}-v*.*.*.jar"):
-        print(f"removing {file.name}")
-        file.unlink(missing_ok=True)
+beta_index_path = REPO_DIR / "index.beta.json"
+if beta_index_path.exists():
+    with beta_index_path.open() as f:
+        remote_release_proto = json_format.Parse(f.read(), index_pb2.Index())
+else:
+    remote_release_proto = index_pb2.Index()
+
+remote_release_extensions = {
+    ext.packageName: ext for ext in remote_release_proto.extensionList.extensions
+}
+
+release_assets_path = REPO_DIR / "release-assets.json"
+if release_assets_path.exists():
+    with release_assets_path.open() as f:
+        release_assets = json.load(f)
+else:
+    release_assets = {}
+
+updated_release_assets = {
+    package_name: assets
+    for package_name, assets in release_assets.items()
+    if not any(package_name.endswith(f".{module}") for module in to_delete)
+}
 
 # Build index entries for the freshly built apks. Each extension's metadata comes from the
 # source-info JSON emitted by its assembleRelease task (see GenerateSourceInfoTask); its APK is a
 # sibling in the same build dir. aapt reads the icon out of the APK
-new_extensions: list[index_pb2.Extension] = []
+new_extensions: list[tuple[index_pb2.Extension, Path, Path, bool]] = []
+published_files: set[Path] = set()
 
 SOURCE_DIR = Path(__file__).resolve().parents[2]
 ICON_FILE = "res/mipmap-xhdpi/ic_launcher.png"
@@ -55,6 +78,7 @@ def get_icon_url(module: str, theme: str | None) -> str:
 
     return f"{ICON_BASE_URL}/core/src/main/{ICON_FILE}"
 
+
 for info_file in ARTIFACTS_DIR.glob("**/keiyoushi-source-info.json"):
     with info_file.open(encoding="utf-8") as f:
         info = json.load(f)
@@ -71,34 +95,80 @@ for info_file in ARTIFACTS_DIR.glob("**/keiyoushi-source-info.json"):
             f"{package_name}: no release jar found under {info_file.parent}"
         )
 
-    (REPO_APK_DIR / apk.name).write_bytes(apk.read_bytes())
-    (REPO_JAR_DIR / jar.name).write_bytes(jar.read_bytes())
+    apk_bytes = apk.read_bytes()
+    jar_bytes = jar.read_bytes()
+    repo_apk = REPO_APK_DIR / apk.name
+    repo_jar = REPO_JAR_DIR / jar.name
 
-    new_extensions.append(
-        index_pb2.Extension(
-            name=info["name"],
-            packageName=package_name,
-            resources=index_pb2.Resources(
-                apkUrl=f"{APK_BASE_URL}/{apk.name}",
-                jarUrl=f"{JAR_BASE_URL}/{jar.name}",
-                iconUrl=get_icon_url(info["module"], info.get("theme")),
-            ),
-            extensionLib=info["extensionLib"],
-            versionCode=info["versionCode"],
-            versionName=info["versionName"],
-            contentWarning=info["contentWarning"],
-            sources=[
-                index_pb2.Source(
-                    id=int(source["id"]),
-                    name=source["name"],
-                    language=source["lang"],
-                    homeUrl=source["baseUrl"],
-                    mirrorUrls=source.get("mirrorUrls", []),
-                )
-                for source in info["sources"]
-            ],
-        )
+    assets = {
+        "apk": {
+            "name": apk.name,
+            "sha256": hashlib.sha256(apk_bytes).hexdigest(),
+        },
+        "jar": {
+            "name": jar.name,
+            "sha256": hashlib.sha256(jar_bytes).hexdigest(),
+        },
+    }
+    changed = (
+        package_name not in remote_release_extensions
+        or release_assets.get(package_name) != assets
     )
+
+    repo_apk.write_bytes(apk_bytes)
+    repo_jar.write_bytes(jar_bytes)
+    published_files.update((repo_apk, repo_jar))
+    updated_release_assets[package_name] = assets
+
+    ext = index_pb2.Extension(
+        name=info["name"],
+        packageName=package_name,
+        resources=index_pb2.Resources(
+            apkUrl=f"{APK_BASE_URL}/{apk.name}",
+            jarUrl=f"{JAR_BASE_URL}/{jar.name}",
+            iconUrl=get_icon_url(info["module"], info.get("theme")),
+        ),
+        extensionLib=info["extensionLib"],
+        versionCode=info["versionCode"],
+        versionName=info["versionName"],
+        contentWarning=info["contentWarning"],
+        sources=[
+            index_pb2.Source(
+                id=int(source["id"]),
+                name=source["name"],
+                language=source["lang"],
+                homeUrl=source["baseUrl"],
+                mirrorUrls=source.get("mirrorUrls", []),
+            )
+            for source in info["sources"]
+        ],
+    )
+    new_extensions.append((ext, apk, jar, changed))
+
+new_extensions.sort(key=lambda item: item[0].packageName)
+
+total_extensions = len(new_extensions)
+release_count = math.ceil(total_extensions / ASSET_LIMIT) if total_extensions else 0
+ext_per_release = math.ceil(total_extensions / release_count) if release_count else 0
+
+
+def get_release_tag(batch_index: int) -> str:
+    return (
+        f"{current_sha_short}-{batch_index}" if release_count > 1 else current_sha_short
+    )
+
+
+# Drop stale repo assets for modules that were deleted or rebuilt. Current artifacts are retained;
+# release upload checks use the checksum manifest above and do not depend on these repo copies.
+for module in to_delete:
+    for file in REPO_APK_DIR.glob(f"tachiyomi-{module}-v*.*.*.apk"):
+        if file not in published_files:
+            print(f"removing {file.name}")
+            file.unlink(missing_ok=True)
+    for file in REPO_JAR_DIR.glob(f"tachiyomi-{module}-v*.*.*.jar"):
+        if file not in published_files:
+            print(f"removing {file.name}")
+            file.unlink(missing_ok=True)
 
 # Merge with the already-published index, dropping the deleted/rebuilt modules.
 with REPO_DIR.joinpath("index.json").open() as f:
@@ -109,30 +179,81 @@ all_extensions = [
     for ext in remote_proto.extensionList.extensions
     if not any(ext.packageName.endswith(f".{module}") for module in to_delete)
 ]
-all_extensions.extend(new_extensions)
+all_extensions.extend([i[0] for i in new_extensions])
 all_extensions.sort(key=lambda ext: ext.packageName)
 
-index = index_pb2.Index(
-    name="Yūzōnō",
-        badgeLabel="Yū",
+new_release_extensions = {}
+for i, (ext, apk, jar, changed) in enumerate(new_extensions):
+    release_ext = index_pb2.Extension()
+    release_ext.CopyFrom(ext)
+
+    if changed:
+        tag = get_release_tag(i // ext_per_release)
+        release_ext.resources.apkUrl = f"{RELEASE_BASE_URL}/{tag}/{apk.name}"
+        release_ext.resources.jarUrl = f"{RELEASE_BASE_URL}/{tag}/{jar.name}"
+    else:
+        old_resources = remote_release_extensions[ext.packageName].resources
+        release_ext.resources.apkUrl = old_resources.apkUrl
+        release_ext.resources.jarUrl = old_resources.jarUrl
+
+    new_release_extensions[ext.packageName] = release_ext
+
+all_release_extensions = []
+for ext in all_extensions:
+    if ext.packageName in new_release_extensions:
+        all_release_extensions.append(new_release_extensions[ext.packageName])
+        continue
+
+    if ext.packageName not in remote_release_extensions:
+        raise ValueError(f"{ext.packageName}: no GitHub release asset mapping found")
+
+    release_ext = index_pb2.Extension()
+    release_ext.CopyFrom(ext)
+    old_resources = remote_release_extensions[ext.packageName].resources
+    release_ext.resources.apkUrl = old_resources.apkUrl
+    release_ext.resources.jarUrl = old_resources.jarUrl
+    all_release_extensions.append(release_ext)
+
+
+def create_index(
+    name: str,
+    badge_label: str,
+    extensions: list[index_pb2.Extension],
+) -> index_pb2.Index:
+    return index_pb2.Index(
+        name=name,
+        badgeLabel=badge_label,
         signingKey="cbec121aa82ebb02aaa73806992e0368a97d47b5451ed6524816d03084c45905",
         contact=index_pb2.Contact(
-            website="https://yuzono.github.io", discord="https://discord.gg/85MZhUX688"
-    ),
-    extensionList=index_pb2.ExtensionList(extensions=all_extensions),
-)
-
-with REPO_DIR.joinpath("index.json").open("w", encoding="utf-8") as f:
-    f.write(
-        json_format.MessageToJson(
-            index,
-            always_print_fields_with_no_presence=False,
-            preserving_proto_field_name=True,
-        )
+            website="https://yuzono.github.io",
+            discord="https://discord.gg/85MZhUX688",
+        ),
+        extensionList=index_pb2.ExtensionList(extensions=extensions),
     )
 
-with REPO_DIR.joinpath("index.pb").open("wb") as f:
-    f.write(gzip.compress(index.SerializeToString(deterministic=True)))
+
+def write_index(filename: str, index: index_pb2.Index):
+    with REPO_DIR.joinpath(f"{filename}.json").open("w", encoding="utf-8") as f:
+        f.write(
+            json_format.MessageToJson(
+                index,
+                always_print_fields_with_no_presence=False,
+                preserving_proto_field_name=True,
+            )
+        )
+
+    with REPO_DIR.joinpath(f"{filename}.pb").open("wb") as f:
+        f.write(gzip.compress(index.SerializeToString(deterministic=True)))
+
+
+index = create_index("Yūzōnō", "Yū", all_extensions)
+release_index = create_index("Yūzōnō (Beta)", "Yū β", all_release_extensions)
+write_index("index", index)
+write_index("index.beta", release_index)
+
+with release_assets_path.open("w", encoding="utf-8") as f:
+    json.dump(updated_release_assets, f, indent=2, sort_keys=True)
+    f.write("\n")
 
 with REPO_DIR.joinpath("index.html").open("w", encoding="utf-8") as f:
     f.write(
@@ -143,3 +264,87 @@ with REPO_DIR.joinpath("index.html").open("w", encoding="utf-8") as f:
         name_escaped = html.escape(f"Tachiyomi: {ext.name}")
         f.write(f'<a href="{apk_escaped}">{name_escaped}</a>\n')
     f.write("</pre>\n</body>\n</html>\n")
+
+# --- Upload assets as release ---
+if not new_extensions:
+    sys.exit(0)
+
+
+def run_gh(*args: str, success_codes: tuple[int, ...] = ()) -> str:
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0 or result.returncode in success_codes:
+        return result.stdout.strip()
+
+    print(f"gh {' '.join(args)} failed: {result.stderr}", file=sys.stderr)
+    sys.exit(result.returncode)
+
+
+def create_release(tag: str):
+    if run_gh(
+        "release",
+        "view",
+        tag,
+        "--repo",
+        REPO_NAME,
+        "--json",
+        "tagName",
+        success_codes=(1,),
+    ):
+        print(f"Release {tag} already exists")
+        return
+
+    print(f"Creating release {tag}")
+    run_gh(
+        "release",
+        "create",
+        tag,
+        "--repo",
+        REPO_NAME,
+        "--draft",
+        "--title",
+        f"Repository Update {tag}",
+        "--notes",
+        f"Automated update from keiyoushi/extensions-source@{current_sha}",
+    )
+
+
+def publish_release(tag: str):
+    print(f"Publishing release {tag}")
+    run_gh("release", "edit", tag, "--repo", REPO_NAME, "--draft=false")
+
+
+def upload_assets(tag: str, files: list[Path]):
+    if not files:
+        return
+    print(f"Uploading {len(files)} assets to {tag}")
+    run_gh(
+        "release",
+        "upload",
+        tag,
+        *[str(f) for f in files],
+        "--repo",
+        REPO_NAME,
+        "--clobber",
+    )
+    publish_release(tag)
+
+
+for i in range(0, total_extensions, ext_per_release):
+    batch = new_extensions[i : i + ext_per_release]
+    tag = get_release_tag(i // ext_per_release)
+    files_to_upload = []
+    for ext, apk, jar, changed in batch:
+        if changed:
+            files_to_upload.extend([apk, jar])
+
+    if not files_to_upload:
+        print(f"Nothing changed for {tag}, skipping release")
+        continue
+
+    create_release(tag)
+    upload_assets(tag, files_to_upload)

--- a/.github/scripts/publish-repo.py
+++ b/.github/scripts/publish-repo.py
@@ -5,6 +5,7 @@ import json
 import math
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import index_pb2
@@ -27,6 +28,14 @@ ICON_BASE_URL = "https://cdn.jsdelivr.net/gh/yuzono/tachiyomi-extensions@master"
 REPO_NAME = "yuzono/manga-repo"
 RELEASE_BASE_URL = f"https://github.com/{REPO_NAME}/releases/download"
 ASSET_LIMIT = 495  # Actual limit is 1000 but we upload 2 items per extension.
+RETRY_ATTEMPTS = 4
+RETRY_BASE_DELAY = 60  # Documented minimum wait; doubles per attempt.
+# Uploading continuously trips a secondary rate limit after roughly 450 assets, and
+# that limit clears again within a few minutes. Pace the uploads well under the rate
+# that trips it. Small calls also cap how much completed work gh re-sends on retry,
+# since it re-uploads the whole call.
+UPLOAD_CHUNK_SIZE = 80
+UPLOAD_CHUNK_INTERVAL = 30
 
 to_delete: list[str] = json.loads(sys.argv[1])
 current_sha = sys.argv[2]
@@ -271,17 +280,33 @@ if not new_extensions:
 
 
 def run_gh(*args: str, success_codes: tuple[int, ...] = ()) -> str:
-    result = subprocess.run(
-        ["gh", *args],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode == 0 or result.returncode in success_codes:
-        return result.stdout.strip()
+    delay = RETRY_BASE_DELAY
+    for attempt in range(1, RETRY_ATTEMPTS + 1):
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0 or result.returncode in success_codes:
+            return result.stdout.strip()
 
-    print(f"gh {' '.join(args)} failed: {result.stderr}", file=sys.stderr)
-    sys.exit(result.returncode)
+        # Secondary rate limits are explicitly retryable after a wait; everything else
+        # is a real failure, so fail fast. The upload endpoint sends no retry-after
+        # header, so back off from the documented one minute minimum.
+        # https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+        if attempt < RETRY_ATTEMPTS and "secondary rate limit" in result.stderr.lower():
+            print(
+                f"secondary rate limit hit, retrying in {delay}s "
+                f"(attempt {attempt}/{RETRY_ATTEMPTS})",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+            delay *= 2
+            continue
+
+        print(f"gh {' '.join(args)} failed: {result.stderr}", file=sys.stderr)
+        sys.exit(result.returncode)
 
 
 def create_release(tag: str):
@@ -322,15 +347,20 @@ def upload_assets(tag: str, files: list[Path]):
     if not files:
         return
     print(f"Uploading {len(files)} assets to {tag}")
-    run_gh(
-        "release",
-        "upload",
-        tag,
-        *[str(f) for f in files],
-        "--repo",
-        REPO_NAME,
-        "--clobber",
-    )
+    for i in range(0, len(files), UPLOAD_CHUNK_SIZE):
+        chunk = files[i : i + UPLOAD_CHUNK_SIZE]
+        if i:
+            time.sleep(UPLOAD_CHUNK_INTERVAL)
+        print(f"  assets {i + 1}-{i + len(chunk)} of {len(files)}")
+        run_gh(
+            "release",
+            "upload",
+            tag,
+            *[str(f) for f in chunk],
+            "--repo",
+            REPO_NAME,
+            "--clobber",
+        )
     publish_release(tag)
 
 

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -150,10 +150,11 @@ jobs:
       - name: Publish repo
         env:
           DELETE: ${{ needs.prepare.outputs.delete }}
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
         run: |
           cd repo
           pip install protobuf
-          python ../${{ github.ref_name }}/.github/scripts/publish-repo.py "$DELETE"
+          python ../${{ github.ref_name }}/.github/scripts/publish-repo.py "$DELETE" "$GITHUB_SHA"
 
       - name: Deploy repo
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10
@@ -179,3 +180,5 @@ jobs:
           curl https://purge.jsdelivr.net/gh/yuzono/manga-repo@repo/index.min.json
           curl https://purge.jsdelivr.net/gh/yuzono/manga-repo@repo/index.json
           curl https://purge.jsdelivr.net/gh/yuzono/manga-repo@repo/index.pb
+          curl https://purge.jsdelivr.net/gh/yuzono/manga-repo@repo/index.beta.json
+          curl https://purge.jsdelivr.net/gh/yuzono/manga-repo@repo/index.beta.pb

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -123,7 +123,7 @@ jobs:
       needs.build.result != 'cancelled' &&
       needs.prepare.outputs.delete != '[]'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 120
     steps:
       - name: Download APK artifacts
         if: needs.build.result == 'success'
@@ -154,7 +154,7 @@ jobs:
         run: |
           cd repo
           pip install protobuf
-          python ../${{ github.ref_name }}/.github/scripts/publish-repo.py "$DELETE" "$GITHUB_SHA"
+          python -u ../${{ github.ref_name }}/.github/scripts/publish-repo.py "$DELETE" "$GITHUB_SHA"
 
       - name: Deploy repo
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -123,7 +123,7 @@ jobs:
       needs.build.result != 'cancelled' &&
       needs.prepare.outputs.delete != '[]'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     steps:
       - name: Download APK artifacts
         if: needs.build.result == 'success'


### PR DESCRIPTION
## Summary by Sourcery

Introduce beta GitHub release publishing for extension assets and maintain a separate beta index alongside the main repository index.

New Features:
- Generate a beta index that maps extensions to GitHub release-hosted APK and JAR assets, separate from the CDN-based main index.
- Publish changed extension APK and JAR files as GitHub releases with automatic tag selection, chunked uploads, and rate-limit-aware retries.
- Track released assets and their checksums in a manifest to detect unchanged artifacts and avoid redundant uploads.

Enhancements:
- Refactor index creation and writing into reusable helpers and ensure deterministic gzip output for protobuf indices.
- Limit removal of stale APK/JAR files in the repo to assets not just published, preventing accidental deletion of current artifacts.

CI:
- Extend the publish job timeout and wire GitHub token and commit SHA into the publish script invocation for release operations.
- Purge jsDelivr cache for the new beta index JSON and protobuf files after publishing.