### PR TITLE
Rename to main

### DIFF
--- a/.github/scripts/cleanup-releases.py
+++ b/.github/scripts/cleanup-releases.py
@@ -1,0 +1,145 @@
+import json
+import time
+from datetime import UTC, datetime, timedelta
+
+from github_utils import REPO_NAME, run_gh
+
+SOURCE_REPO = "yuzono/tachiyomi-extensions"
+PUBLISH_WORKFLOW = "build_push.yml"
+PUBLISH_JOB = "Publish extension repo"
+MIN_PUBLISH_AGE = timedelta(hours=1)
+POLL_INTERVAL = 60
+DELETE_INTERVAL = 1
+
+
+def get_json(endpoint: str):
+    return json.loads(run_gh("api", endpoint))
+
+
+def get_pages(endpoint: str) -> list[dict]:
+    items = []
+    page = 1
+    separator = "&" if "?" in endpoint else "?"
+    while True:
+        batch = get_json(f"{endpoint}{separator}per_page=100&page={page}")
+        items.extend(batch)
+        if len(batch) < 100:
+            return items
+        page += 1
+
+
+def get_workflow_runs() -> list[dict]:
+    return get_json(
+        f"repos/{SOURCE_REPO}/actions/workflows/{PUBLISH_WORKFLOW}/runs?per_page=20"
+    )["workflow_runs"]
+
+
+def get_latest_publish_job(runs: list[dict]) -> dict | None:
+    publish_jobs = []
+    for run in runs:
+        jobs = get_json(
+            f"repos/{SOURCE_REPO}/actions/runs/{run['id']}/jobs?per_page=100"
+        )["jobs"]
+        publish_jobs.extend(
+            job
+            for job in jobs
+            if job["name"] == PUBLISH_JOB and job.get("conclusion") != "skipped"
+        )
+
+    if not publish_jobs:
+        return None
+
+    return max(publish_jobs, key=lambda job: job["completed_at"])
+
+
+def wait_for_publish_window() -> None:
+    while True:
+        runs = get_workflow_runs()
+        active_runs = [run for run in runs if run["status"] != "completed"]
+        if active_runs:
+            run = active_runs[0]
+            print(f"CI run {run['id']} is {run['status']}; checking again in 60s")
+            time.sleep(POLL_INTERVAL)
+            continue
+
+        job = get_latest_publish_job(runs)
+        if job is None:
+            print("No previous publish job found")
+            return
+
+        safe_at = datetime.fromisoformat(job["completed_at"]) + MIN_PUBLISH_AGE
+        remaining = (safe_at - datetime.now(UTC)).total_seconds()
+        if remaining <= 0:
+            return
+
+        print(
+            f"Publish job {job['id']} completed less than an hour ago; "
+            f"waiting until {safe_at.isoformat()}"
+        )
+        time.sleep(remaining)
+
+
+def get_referenced_assets() -> set[str]:
+    index = json.loads(
+        run_gh(
+            "api",
+            "--header",
+            "Accept: application/vnd.github.raw+json",
+            f"repos/{REPO_NAME}/contents/index.json?ref=repo",
+        )
+    )
+    return {
+        extension["resources"][field]
+        for extension in index["extensionList"]["extensions"]
+        for field in ("apkUrl", "jarUrl")
+    }
+
+
+def cleanup_releases(referenced: set[str]) -> tuple[int, int]:
+    deleted_assets = 0
+    deleted_releases = 0
+    releases = get_pages(f"repos/{REPO_NAME}/releases")
+
+    for release in releases:
+        assets = get_pages(f"repos/{REPO_NAME}/releases/{release['id']}/assets")
+        remaining = len(assets)
+        for asset in assets:
+            if asset["browser_download_url"] in referenced:
+                continue
+
+            print(f"Deleting {release['tag_name']}/{asset['name']}")
+            run_gh(
+                "api",
+                "--method",
+                "DELETE",
+                f"repos/{REPO_NAME}/releases/assets/{asset['id']}",
+            )
+            deleted_assets += 1
+            remaining -= 1
+            time.sleep(DELETE_INTERVAL)
+
+        if remaining == 0:
+            print(f"Deleting empty release {release['tag_name']}")
+            run_gh(
+                "api",
+                "--method",
+                "DELETE",
+                f"repos/{REPO_NAME}/releases/{release['id']}",
+            )
+            deleted_releases += 1
+
+    return deleted_assets, deleted_releases
+
+
+def main() -> None:
+    wait_for_publish_window()
+    referenced_assets = get_referenced_assets()
+    asset_count, release_count = cleanup_releases(referenced_assets)
+    summary = (
+        f"Deleted {asset_count} unreferenced assets and {release_count} empty releases"
+    )
+    print(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/github_utils.py
+++ b/.github/scripts/github_utils.py
@@ -1,0 +1,50 @@
+import subprocess
+import time
+
+REPO_NAME = "cuong-tran/manga-repo"
+RETRY_ATTEMPTS = 4
+RETRY_BASE_DELAY = 60
+
+
+def run_gh(*args: str, success_errors: tuple[str, ...] = ()) -> str:
+    attempt = 1
+    delay = RETRY_BASE_DELAY
+    while True:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            encoding="utf-8",
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+
+        error = result.stderr.lower()
+        if any(success_error in error for success_error in success_errors):
+            return result.stdout.strip()
+
+        if "secondary rate limit" in error and attempt < RETRY_ATTEMPTS:
+            retry_delay = delay
+            delay *= 2
+        elif "api rate limit exceeded" in error and attempt < RETRY_ATTEMPTS:
+            rate_limit = subprocess.run(
+                ["gh", "api", "rate_limit", "--jq", ".resources.core.reset"],
+                capture_output=True,
+                encoding="utf-8",
+                check=False,
+            )
+            retry_delay = RETRY_BASE_DELAY
+            if rate_limit.returncode == 0:
+                retry_delay = max(
+                    int(rate_limit.stdout.strip()) - int(time.time()) + 10,
+                    RETRY_BASE_DELAY,
+                )
+        else:
+            raise RuntimeError(f"gh {' '.join(args)} failed: {result.stderr.strip()}")
+
+        print(
+            f"GitHub rate limit hit; retrying in {retry_delay}s "
+            f"(attempt {attempt}/{RETRY_ATTEMPTS})"
+        )
+        time.sleep(retry_delay)
+        attempt += 1

--- a/.github/scripts/publish-apk.py
+++ b/.github/scripts/publish-apk.py
@@ -21,7 +21,7 @@ REPO_JAR_DIR.mkdir(parents=True, exist_ok=True)
 
 APK_BASE_URL = "https://cdn.jsdelivr.net/gh/yuzono/tachiyomi-repo@repo/apk"
 JAR_BASE_URL = "https://raw.githubusercontent.com/yuzono/tachiyomi-repo/repo/jar"
-ICON_BASE_URL = "https://cdn.jsdelivr.net/gh/yuzono/tachiyomi-extensions@master"
+ICON_BASE_URL = "https://cdn.jsdelivr.net/gh/yuzono/tachiyomi-extensions@main"
 
 to_delete: list[str] = json.loads(sys.argv[1])
 

--- a/.github/scripts/publish-repo.py
+++ b/.github/scripts/publish-repo.py
@@ -18,7 +18,7 @@ ARTIFACTS_DIR = Path.home() / "apk-artifacts"
 # The checked-out `repo` branch we publish into (the working directory).
 REPO_DIR = Path.cwd()
 
-ICON_BASE_URL = "https://cdn.jsdelivr.net/gh/yuzono/tachiyomi-extensions@master"
+ICON_BASE_URL = "https://cdn.jsdelivr.net/gh/yuzono/tachiyomi-extensions@main"
 RELEASE_BASE_URL = f"https://github.com/{REPO_NAME}/releases/download"
 ASSET_LIMIT = 495  # Actual limit is 1000 but we upload 2 items per extension.
 UPLOAD_CHUNK_SIZE = 80

--- a/.github/scripts/publish-repo.py
+++ b/.github/scripts/publish-repo.py
@@ -3,12 +3,12 @@ import hashlib
 import html
 import json
 import math
-import subprocess
 import sys
 import time
 from pathlib import Path
 
 import index_pb2
+from github_utils import REPO_NAME, run_gh
 from google.protobuf import json_format
 
 # Artifacts downloaded from the build jobs: one APK per extension plus the source metadata JSON
@@ -19,11 +19,8 @@ ARTIFACTS_DIR = Path.home() / "apk-artifacts"
 REPO_DIR = Path.cwd()
 
 ICON_BASE_URL = "https://cdn.jsdelivr.net/gh/yuzono/tachiyomi-extensions@master"
-REPO_NAME = "cuong-tran/manga-repo"
 RELEASE_BASE_URL = f"https://github.com/{REPO_NAME}/releases/download"
 ASSET_LIMIT = 495  # Actual limit is 1000 but we upload 2 items per extension.
-RETRY_ATTEMPTS = 4
-RETRY_BASE_DELAY = 60  # Documented minimum wait; doubles per attempt.
 UPLOAD_CHUNK_SIZE = 80
 UPLOAD_CHUNK_INTERVAL = 30
 
@@ -202,62 +199,6 @@ with REPO_DIR.joinpath("index.html").open("w", encoding="utf-8") as f:
 # --- Upload assets as release ---
 if not new_extensions:
     sys.exit(0)
-
-
-def run_gh(*args: str, success_errors: tuple[str, ...] = ()) -> str:
-    delay = RETRY_BASE_DELAY
-    for attempt in range(1, RETRY_ATTEMPTS + 1):
-        result = subprocess.run(
-            ["gh", *args],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode == 0:
-            return result.stdout.strip()
-
-        error = result.stderr.lower()
-
-        # The upload endpoint does not expose retry headers through gh, so use the
-        # documented one-minute minimum with exponential backoff for secondary limits.
-        # https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
-        if "secondary rate limit" in error:
-            if attempt < RETRY_ATTEMPTS:
-                print(
-                    f"secondary rate limit hit, retrying in {delay}s "
-                    f"(attempt {attempt}/{RETRY_ATTEMPTS})",
-                    file=sys.stderr,
-                )
-                time.sleep(delay)
-                delay *= 2
-                continue
-
-        elif "api rate limit exceeded" in error and attempt < RETRY_ATTEMPTS:
-            rate_limit = subprocess.run(
-                ["gh", "api", "rate_limit", "--jq", ".resources.core.reset"],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            retry_delay = RETRY_BASE_DELAY
-            if rate_limit.returncode == 0:
-                retry_delay = max(
-                    int(rate_limit.stdout.strip()) - int(time.time()) + 10,
-                    RETRY_BASE_DELAY,
-                )
-            print(
-                f"API rate limit hit, retrying in {retry_delay}s "
-                f"(attempt {attempt}/{RETRY_ATTEMPTS})",
-                file=sys.stderr,
-            )
-            time.sleep(retry_delay)
-            continue
-
-        elif any(success_error in error for success_error in success_errors):
-            return result.stdout.strip()
-
-        print(f"gh {' '.join(args)} failed: {result.stderr}", file=sys.stderr)
-        sys.exit(result.returncode)
 
 
 def create_release(tag: str):

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -26,17 +26,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Clone master
+      - name: Clone main
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: master
-          path: master
+          ref: main
+          path: main
           fetch-depth: 100
           token: ${{ secrets.BOT_PAT }}
 
       - name: Cherry-picking
         run: |
-          cd master
+          cd main
 
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
@@ -58,7 +58,7 @@ jobs:
             upcoming_changes_hash+=("$line")
           done <<< "$upcoming_changes"
 
-          git checkout master
+          git checkout main
           echo "Last commit: `git log -1 --oneline`"
           # Loop through indices in reverse order
           for (( i=${#upcoming_changes_hash[@]}; i>=0; i-- )); do
@@ -77,7 +77,7 @@ jobs:
 
       - name: Merging keiyoushi-upstream to keiyoushi
         run: |
-          cd master
+          cd main
           git checkout keiyoushi
           echo "Last commit: `git log -1 --oneline`"
           latest_commit_hash=${{ env.LATEST_HASH }}
@@ -88,29 +88,29 @@ jobs:
 
           echo "Last commit: `git log -1 --oneline`"
 
-      # - name: Merging master to merge-keiyoushi
+      # - name: Merging main to merge-keiyoushi
       #   run: |
-      #     cd master
+      #     cd main
       #     git fetch origin merge-keiyoushi
       #     git checkout merge-keiyoushi
       #     echo "Last commit: `git log -1 --oneline`"
-      #     echo "Merging 'master' into merge-keiyoushi"
-      #     git merge --no-edit master
+      #     echo "Merging 'main' into merge-keiyoushi"
+      #     git merge --no-edit main
       #     echo "Last commit: `git log -1 --oneline`"
 
       # - name: Merging keiyoushi-upstream to merge-keiyoushi
       #   run: |
-      #     cd master
+      #     cd main
       #     echo "Merging 'keiyoushi-upstream/main' into merge-keiyoushi"
       #     git merge --no-edit keiyoushi-upstream/main
       #     echo "Last commit: `git log -1 --oneline`"
 
       - name: Pushing to repo
         run: |
-          cd master
-          git checkout master
+          cd main
+          git checkout main
           echo "Last commit: `git log -1 --oneline`"
-          echo "Pushing 'master' to repo"
+          echo "Pushing 'main' to repo"
           git push
           git checkout keiyoushi
           echo "Last commit: `git log -1 --oneline`"

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -36,7 +36,7 @@ jobs:
       - id: generate-matrices
         name: Generate build matrices
         run: |
-          python ./.github/scripts/generate-build-matrices.py origin/master Release
+          python ./.github/scripts/generate-build-matrices.py origin/main Release
 
   build:
     name: Build extensions (${{ matrix.chunk.number }})

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches:
-      # - main
-      - master
+      - main
     paths:
       - '**'
       - '!**.md'

--- a/.github/workflows/cleanup_releases.yml
+++ b/.github/workflows/cleanup_releases.yml
@@ -1,0 +1,30 @@
+name: Clean up releases
+
+on:
+  schedule:
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Remove unreferenced release assets
+    if: github.repository == 'yuzono/tachiyomi-extensions'
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Clean up releases
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+        run: python -u .github/scripts/cleanup-releases.py

--- a/.github/workflows/codeberg_mirror.yml
+++ b/.github/workflows/codeberg_mirror.yml
@@ -3,7 +3,7 @@ name: Mirror Sync
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   workflow_dispatch: # Manual dispatch
   schedule:
     - cron: "0 */8 * * *"
@@ -28,6 +28,6 @@ jobs:
       - name: Mirror repository
         run: |
           git remote add mirror "git@codeberg.org:cuong-tran/tachiyomi-extensions.git"
-          git push --force --prune mirror "refs/remotes/origin/master:refs/heads/master"
+          git push --force --prune mirror "refs/remotes/origin/main:refs/heads/main"
         env:
           GIT_SSH_COMMAND: "ssh -v -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -l git"

--- a/.github/workflows/delete_merged_branch.yml
+++ b/.github/workflows/delete_merged_branch.yml
@@ -22,7 +22,7 @@ jobs:
             echo "Deleting branch ${branch_name}"
             git push origin --delete $branch_name
           else
-            echo "Skipping deletion of main or master branch"
+            echo "Skipping deletion of main or main/master branch"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,7 +3,7 @@ name: GitHub Actions Security Analysis
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - .github/workflows/**
   pull_request:


### PR DESCRIPTION
## Summary by Sourcery

Switch repository and workflows to use the main branch and introduce automated cleanup of unused release assets.

New Features:
- Add a scheduled GitHub Actions workflow to run a release cleanup job using a new cleanup-releases script.
- Introduce a cleanup-releases script that removes unreferenced release assets and empty releases from the manga repo.

Enhancements:
- Centralize GitHub CLI helper logic and repository configuration into a shared github_utils module.
- Update CDN and repository URLs in publishing scripts to reference the main branch instead of master.

CI:
- Update existing CI and utility workflows to operate on the main branch rather than master, including cherry-pick, mirror sync, PR builds, and security analysis.
- Refine branch deletion workflow messaging to explicitly protect both main and master branches.